### PR TITLE
insights_mcp: fix returning user friendly message on OAuthError

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -46,7 +46,8 @@ class TestAuthentication:
 
             # Should return authentication error
             # The actual implementation makes API calls and gets 401 errors when no auth is provided
-            assert result.startswith("Error:")
+            assert "Invalid client or Invalid client credentials" in result
+            assert "[INSTRUCTION]" in result
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("function_name,kwargs", AUTH_FUNCTIONS)


### PR DESCRIPTION
Fix returning user friendly message on `OAuthError`

There is an additional implementation in `image_builder_mcp` to handle those errors, that could probably be removed now (as we unified the implementation and error handling in `insights_mcp`

Details:
This fixes instead of just returning `unauthorized_client: Invalid client or Invalid client credentials` the MCP server returns the user description, where to get the client ID and secret.