### PR TITLE
README: link to test prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,5 +223,13 @@ e.g.
 Please explain insights-mcp and what I can do with it?
 ```
 
+For example questions specific to each toolset please have a look at the test files:
+
+ * [`image-builder-mcp`](src/image_builder_mcp/tests/test_llm_integration_easy.py#L20)
+ * [`inventory-mcp`](src/inventory_mcp/test_prompts.md)
+ * [`remediations-mcp`](src/remediations_mcp/test_prompts.md)
+ * [`rhel-advisor-mcp`](src/rhel_advisor_mcp/test_prompts.md)
+ * [`vulnerability-mcp`](src/vulnerability_mcp/test_prompts.md)
+
 ## Contributing
 Please refer to the [hacking guide](HACKING.md) to learn more.

--- a/src/image_builder_mcp/tests/test_llm_integration_hard.py
+++ b/src/image_builder_mcp/tests/test_llm_integration_hard.py
@@ -12,6 +12,9 @@ from tests.utils import (
     should_skip_llm_matrix_tests,
 )
 
+# Test prompts
+TEST_COMPLETE_CONVERSATION_FLOW_PROMPT = "Can you help me understand what blueprints are available?"
+
 # Load LLM configurations for parametrization
 llm_configurations, _ = load_llm_configurations()
 
@@ -26,7 +29,7 @@ class TestLLMIntegrationHard:
     async def test_complete_conversation_flow(self, test_agent, guardian_agent, verbose_logger, llm_config):  # pylint: disable=redefined-outer-name
         """Test complete conversation flow with proper agent behavior."""
 
-        prompt = "Can you help me understand what blueprints are available?"
+        prompt = TEST_COMPLETE_CONVERSATION_FLOW_PROMPT
 
         response, _, tools_executed, _ = await test_agent.execute_with_reasoning(prompt, chat_history=[])
 

--- a/src/inventory_mcp/test_prompts.md
+++ b/src/inventory_mcp/test_prompts.md
@@ -1,4 +1,4 @@
-# Test Prompts
+# Inventory MCP Test Prompts
 - List all hosts running RHEL 9 that were last seen in the past day
 - Show me the top 5 most recently active hosts
 - Get details for host named 'web-server-prod-01'

--- a/src/remediations_mcp/test_prompts.md
+++ b/src/remediations_mcp/test_prompts.md
@@ -1,3 +1,3 @@
-# Test Prompts
+# Remediations MCP Test Prompts
 - Remediate `CVE-XXXX-XXXX` on system `YYY`
 - Remediate `CVE-XXXX-XXXX` on system `YYY` and give me remediation playbook in `yaml` format

--- a/src/rhel_advisor_mcp/test_prompts.md
+++ b/src/rhel_advisor_mcp/test_prompts.md
@@ -1,4 +1,4 @@
-# Test Prompts
+# Advisor MCP Test Prompts
 - Show me the top 5 critical issues on my systems
 - I saw a Knowledge Base Article https://access.redhat.com/articles/6464541; does any of my systems are affected by the issue it describes?
 - List all the affected recommendations that have automated solutions available

--- a/src/vulnerability_mcp/test_prompts.md
+++ b/src/vulnerability_mcp/test_prompts.md
@@ -1,4 +1,4 @@
-# Test Prompts
+# Vulnerability MCP Test Prompts
 - Show the top 5 critical CVEs sorted by the number of exposed systems
 - Are there any CVEs with known exploit affecting any of my systems
 - Show me which specific systems are affected by `CVE-XXXX-XXXX`


### PR DESCRIPTION
For easier understanding what can be done with `insights-mcp`, we'll just link the `test_prompts.md` or test implementations.