### PR TITLE
chore: adjust remediation test prompts

### DIFF
--- a/src/remediations_mcp/test_prompts.md
+++ b/src/remediations_mcp/test_prompts.md
@@ -1,3 +1,3 @@
 # Remediations MCP Test Prompts
-- Remediate `CVE-XXXX-XXXX` on system `YYY`
-- Remediate `CVE-XXXX-XXXX` on system `YYY` and give me remediation playbook in `yaml` format
+- Create remediation playbook for `CVE-XXXX-XXXX` on system `YYY`
+- Create remediation playbook for `CVE-XXXX-XXXX` on system `YYY` and give me remediation playbook in `yaml` format


### PR DESCRIPTION
make it clear that remediation mcp can only create remediation playbook and not actually run remediation on a system