### PR TITLE
Improve Claude Desktop extension build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,16 @@ build: generate-docs ## Build the container image
 
 # please set from outside
 TAG ?= UNKNOWN
+CONTAINER_IMAGE ?= ghcr.io/redhatinsights/insights-mcp:latest
 
 .PHONY: build-claude-extension
 build-claude-extension: ## Build the Claude extension
-	sed -i.bak "s/---VERSION---/$(TAG)/g" claude_desktop/manifest.json && rm claude_desktop/manifest.json.bak
-	zip -j insights-mcp-$(TAG).dxt claude_desktop/*
-	sed -i.bak "s/$(TAG)/---VERSION---/g" claude_desktop/manifest.json && rm claude_desktop/manifest.json.bak
+	sed "s/{{VERSION}}/$(TAG)/g; s|{{CONTAINER_IMAGE}}|$(CONTAINER_IMAGE)|g" claude_desktop/manifest.json.template > claude_desktop/manifest.json
+	zip -j insights-mcp-$(TAG).dxt claude_desktop/manifest.json claude_desktop/icon.png
+	rm claude_desktop/manifest.json
+
+build-claude-extension-dev: ## Build Claude extension for local development
+	$(MAKE) build-claude-extension TAG=local-dev CONTAINER_IMAGE=localhost/insights-mcp:latest
 
 .PHONY: lint
 lint: generate-docs ## Run linting with pre-commit

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build-claude-extension: ## Build the Claude extension
 	zip -j insights-mcp-$(TAG).dxt claude_desktop/manifest.json claude_desktop/icon.png
 	rm claude_desktop/manifest.json
 
-build-claude-extension-dev: ## Build Claude extension for local development
+build-claude-extension-dev: build ## Build Claude extension for local development
 	$(MAKE) build-claude-extension TAG=local-dev CONTAINER_IMAGE=localhost/insights-mcp:latest
 
 .PHONY: lint

--- a/claude_desktop/manifest.json.template
+++ b/claude_desktop/manifest.json.template
@@ -2,7 +2,7 @@
   "dxt_version": "0.2",
   "name": "insights-mcp",
   "display_name": "Insights MCP",
-  "version": "---VERSION---",
+  "version": "{{VERSION}}",
   "description": "Interact with Red Hat Insights services like the hosted image builder.\n_REQUIRES_ `podman` to be installed!",
   "author": {
     "name": "Florian Schüller",
@@ -23,7 +23,7 @@
             "INSIGHTS_CLIENT_SECRET",
             "--interactive",
             "--rm",
-            "ghcr.io/redhatinsights/insights-mcp:latest"
+            "{{CONTAINER_IMAGE}}"
       ],
       "env": {
             "INSIGHTS_CLIENT_ID": "${user_config.INSIGHTS_CLIENT_ID}",


### PR DESCRIPTION
- Add CONTAINER_IMAGE parameter to build-claude-extension target
- Create build-claude-extension-dev target for streamlined local development
- Automatically handles container image substitution and restoration
- Eliminates need for manual manifest editing during development

Usage:
- make build-claude-extension-dev (for local development)
- make build-claude-extension TAG=version CONTAINER_IMAGE=image (custom builds)

🤖 Generated with [Claude Code](https://claude.ai/code)