### PR TITLE
README: avoid 60 character limit by configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ the following content.
         }
     ],
     "servers": {
-        "insights-mcp-stdio": {
+        "insights-mcp": {
             "type": "stdio",
             "command": "podman",
             "args": [
@@ -158,7 +158,7 @@ then integrate:
 ```
 {
     "mcpServers": {
-        "insights-mcp-http": {
+        "insights-mcp": {
             "type": "http",
             "url": "http://localhost:8000/mcp",
             "headers": {


### PR DESCRIPTION
It was reported that MCP Clients like cursor have problems with "long" tool names, and shortening the name of the MCP server itself in the configuration seems to help for now.