### PR TITLE
README: add hint that cursor installer closes the tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ the following content.
 
 Try this one-click installation or follow the instructions below.
 
+⚠️ Use **`Ctrl`/`Cmd`-click** to open in a **new tab**.<br>
+Otherwise the tab will close after installation and you won't see the documentation anymore.<br>
 [![Install with Podman in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=insights-mcp&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoicG9kbWFuIHJ1biAtLWVudiBJTlNJR0hUU19DTElFTlRfSUQgLS1lbnYgSU5TSUdIVFNfQ0xJRU5UX1NFQ1JFVCAtLWludGVyYWN0aXZlIC0tcm0gcXVheS5pby9yZWRoYXQtc2VydmljZXMtcHJvZC9pbnNpZ2h0cy1tYW5hZ2VtZW50LXRlbmFudC9pbnNpZ2h0cy1tY3AvaW5zaWdodHMtbWNwOmxhdGVzdCIsImVudiI6eyJJTlNJR0hUU19DTElFTlRfSUQiOiIiLCJJTlNJR0hUU19DTElFTlRfU0VDUkVUIjoiIn19)<br>
 (Note: this uses the `quay.io` container image)
 


### PR DESCRIPTION
@ksiekl Thanks for your finding!

Unfortunately GitHub doesn't support opening in a new tab, so I added a hint.
What do you think?