### PR TITLE
inventory: shrink inventory responses

### DIFF
--- a/src/inventory_mcp/server.py
+++ b/src/inventory_mcp/server.py
@@ -4,9 +4,14 @@ MCP server for host inventory data via Red Hat Insights API.
 Provides tools to get host inventory data for systems connected to Insights.
 """
 
-from typing import Any
+from typing import Annotated, Any
+
+from pydantic import Field
 
 from insights_mcp.mcp import InsightsMCP
+
+# For the API documentation, see:
+# https://github.com/RedHatInsights/insights-host-inventory/tree/master/swagger
 
 mcp = InsightsMCP(
     name="Insights Inventory MCP Server",
@@ -25,36 +30,37 @@ mcp = InsightsMCP(
 
 @mcp.tool()
 async def list_hosts(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-    hostname_or_id: str = "",
-    display_name: str = "",
-    fqdn: str = "",
-    tags: str = "",
-    staleness: str = "",
-    registered_with: str = "",
-    provider_type: str = "",
-    updated_start: str = "",
-    updated_end: str = "",
-    limit: int = 10,
-    offset: int = 0,
-    order_by: str = "",
-    order_how: str = "ASC",
+    hostname_or_id: Annotated[str, Field("", description="Filter by display_name, fqdn, or id (case-insensitive).")],
+    display_name: Annotated[str, Field("", description="Filter by display name (case-insensitive).")],
+    fqdn: Annotated[str, Field("", description="Filter by FQDN (case-insensitive).")],
+    tags: Annotated[str, Field("", description="Filter by tags (e.g., 'ns1/key1=val1,ns2/key2=val2').")],
+    staleness: Annotated[
+        str, Field("", description="Filter by staleness status (one of 'fresh', 'stale', 'stale_warning', 'unknown').")
+    ],
+    registered_with: Annotated[str, Field("", description="Filter by reporter that registered the host.")],
+    provider_type: Annotated[str, Field("", description="Filter by provider type (e.g., 'aws', 'azure', 'gcp').")],
+    updated_start: Annotated[str, Field("", description="Filter hosts updated after this timestamp (RFC3339).")],
+    updated_end: Annotated[str, Field("", description="Filter hosts updated before this timestamp (RFC3339).")],
+    per_page: Annotated[
+        int,
+        Field(
+            10,
+            description=(
+                "Number of hosts to return per page "
+                "**ALWAYS use the default value of 10 for the first call.** "
+                "This default is carefully chosen for performance and context management. "
+                "Only increase this value if the user explicitly asks to see more systems at once "
+            ),
+        ),
+    ],
+    page: Annotated[int, Field(1, description="Page number to return.")],
+    order_by: Annotated[str, Field("", description="Field to sort by ('display_name', 'updated', 'created').")],
+    order_how: Annotated[str, Field("ASC", description="Sort direction ('ASC' or 'DESC').")],
 ) -> dict[str, Any] | str:
     """List hosts with filtering and sorting options.
-
-    Args:
-        hostname_or_id: Filter by display_name, fqdn, or id (case-insensitive).
-        display_name: Filter by display name (case-insensitive).
-        fqdn: Filter by FQDN (case-insensitive).
-        tags: Filter by tags (e.g., 'ns1/key1=val1,ns2/key2=val2').
-        staleness: Filter by staleness status ('fresh', 'stale', 'stale_warning', 'unknown').
-        registered_with: Filter by reporter that registered the host.
-        provider_type: Filter by provider type (e.g., 'aws', 'azure', 'gcp').
-        updated_start: Filter hosts updated after this timestamp (RFC3339).
-        updated_end: Filter hosts updated before this timestamp (RFC3339).
-        limit: Maximum number of hosts to return (1-100).
-        offset: Number of hosts to skip for pagination.
-        order_by: Field to sort by ('display_name', 'updated', 'created').
-        order_how: Sort direction ('ASC' or 'DESC').
+    CRITICAL: For the 'per_page' parameter, you MUST use a value of 10 on the first call to avoid performance
+    degradation and context overflow.
+    Only use a larger value if the user explicitly requests to see more systems at once.
     """
     params: dict[str, Any] = {}
 
@@ -80,8 +86,8 @@ async def list_hosts(  # pylint: disable=too-many-arguments,too-many-positional-
         params["order_by"] = order_by
         params["order_how"] = order_how
 
-    params["limit"] = min(limit, 100)
-    params["offset"] = offset
+    params["per_page"] = min(per_page, 100)
+    params["page"] = page
 
     response = await mcp.insights_client.get("hosts", params=params)
     if isinstance(response, str):
@@ -108,7 +114,19 @@ async def get_host_details(host_ids: str) -> dict[str, Any] | str:
 
 
 @mcp.tool()
-async def get_host_system_profile(host_ids: str) -> dict[str, Any] | str:
+async def get_host_system_profile(
+    host_ids: Annotated[
+        str,
+        Field(
+            "",
+            description=(
+                "Comma-separated list of host IDs (UUIDs) to get system profiles for. "
+                "ALWAYS supply one or two UUIDs at a time! "
+                "Expect really large responses which will overload your context."
+            ),
+        ),
+    ],
+) -> dict[str, Any] | str:
     """Get detailed system profile information for specific hosts.
 
     Returns comprehensive hardware and software configuration data including CPU details
@@ -117,9 +135,6 @@ async def get_host_system_profile(host_ids: str) -> dict[str, Any] | str:
     various system state data. For RHEL hosts, also includes software information such as
     enabled repositories, installed packages, and enabled services. This provides the most
     detailed technical specifications for each host.
-
-    Args:
-        host_ids: Comma-separated list of host IDs (UUIDs) to get system profiles for.
     """
     response = await mcp.insights_client.get(f"hosts/{host_ids}/system_profile")
     if isinstance(response, str):
@@ -147,7 +162,7 @@ async def find_host_by_name(hostname: str) -> dict[str, Any] | str:
     Args:
         hostname: The hostname or display name to search for.
     """
-    response = await mcp.insights_client.get("hosts", params={"hostname_or_id": hostname, "limit": 1})
+    response = await mcp.insights_client.get("hosts", params={"hostname_or_id": hostname, "per_page": 1})
     if isinstance(response, str):
         return response
     return response


### PR DESCRIPTION
Paging parameter is called per_page and not "limit" in the inventory API.
Also it was hard to convince AI (e.g. Claude Sonnet 4) to stick to 10 in the normal request.