### PR TITLE
image-builder: fix returning error string directly

### DIFF
--- a/src/image_builder_mcp/server.py
+++ b/src/image_builder_mcp/server.py
@@ -298,6 +298,9 @@ class ImageBuilderMCP(InsightsMCP):
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error: {str(e)} in blueprint_compose {blueprint_uuid}"
 
+        if isinstance(response, str):
+            return response
+
         response_str = "[INSTRUCTION] Use the tool get_compose_details to get the details of the compose\n"
         response_str += "like the current build status\n"
         response_str += "[ANSWER] Compose created successfully:"


### PR DESCRIPTION
When the upstream REST API failed in `blueprint_compose()`  the error was garbled in the loop over the expected array below.
Like the other MCP tools of image-builder we just return the content if we get a string (which is an error)