### PR TITLE
fix: return insights-mcp version number in the initial call (HMS-10651)

### DIFF
--- a/src/insights_mcp/mcp.py
+++ b/src/insights_mcp/mcp.py
@@ -6,7 +6,6 @@ Insights-specific MCP tools and resources.
 """
 
 import asyncio
-from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.server.auth import AuthProvider
@@ -37,7 +36,6 @@ class InsightsMCP(FastMCP):
         *,
         headers: dict[str, str] | None = None,
         instructions: str | None = None,
-        **settings: Any,
     ):
         """Initialize the InsightsMCP server.
 
@@ -47,9 +45,8 @@ class InsightsMCP(FastMCP):
             api_path: API path for Insights endpoints
             headers: Optional additional HTTP headers for requests
             instructions: Optional instructions for the MCP server
-            **settings: Additional settings passed to FastMCP
         """
-        super().__init__(name=name, instructions=instructions, **settings)
+        super().__init__(name=name, instructions=instructions)
         self.api_path = api_path
         self.toolset_name = toolset_name
         self.headers = headers or {}

--- a/src/insights_mcp/server.py
+++ b/src/insights_mcp/server.py
@@ -106,7 +106,6 @@ class InsightsMCPServer(FastMCP):  # pylint: disable=too-many-instance-attribute
         mcp_host: MCP server host for authentication
         mcp_port: MCP server port for authentication
         token_endpoint: Token endpoint for authentication
-        **settings: Additional settings passed to parent class
     """
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -124,7 +123,6 @@ class InsightsMCPServer(FastMCP):  # pylint: disable=too-many-instance-attribute
         mcp_host: str | None = None,
         mcp_port: int | None = None,
         token_endpoint: str = config.SSO_TOKEN_ENDPOINT,
-        **settings: Any,
     ):
         name = name or "Red Hat Insights"
         server_version = __version__ if __version__ else "0.0.0-dev"
@@ -148,7 +146,6 @@ class InsightsMCPServer(FastMCP):  # pylint: disable=too-many-instance-attribute
             auth=oauth_provider,
             icons=[Icon(src=get_icon_data_uri())],
             website_url="https://console.redhat.com",
-            **settings,
         )
         self.base_url = base_url
         self.client_id = client_id

--- a/src/insights_mcp/server.py
+++ b/src/insights_mcp/server.py
@@ -127,6 +127,7 @@ class InsightsMCPServer(FastMCP):  # pylint: disable=too-many-instance-attribute
         **settings: Any,
     ):
         name = name or "Red Hat Insights"
+        server_version = __version__ if __version__ else "0.0.0-dev"
 
         # Create the OAuth provider
         oauth_provider = (
@@ -143,6 +144,7 @@ class InsightsMCPServer(FastMCP):  # pylint: disable=too-many-instance-attribute
         super().__init__(
             name=name,
             instructions=instructions,
+            version=server_version,
             auth=oauth_provider,
             icons=[Icon(src=get_icon_data_uri())],
             website_url="https://console.redhat.com",


### PR DESCRIPTION
Only in the initial API call towards the MCP server itself the version number returned is the one from FastMCP.
We'll override here to make the version of our MCP server available on the first API calls.