### PR TITLE
[RSPEED-3032] Fix(planning): correct include_related type in get_relevant_rhel_lifecycle

### DIFF
--- a/src/planning_mcp/server.py
+++ b/src/planning_mcp/server.py
@@ -294,17 +294,17 @@ class PlanningMCP(InsightsMCP):
             ),
         ] = "",
         include_related: Annotated[
-            str,
+            bool,
             Field(
-                default="false",
+                default=False,
                 description=(
-                    "When 'true', returns both RHEL versions observed in inventory and additional "
+                    "When true, returns both RHEL versions observed in inventory and additional "
                     "higher-minor or future versions of the same major that are still supported but "
-                    "not yet deployed (marked as related=true). When 'false', returns only RHEL "
+                    "not yet deployed (marked as related=true). When false, returns only RHEL "
                     "versions actually observed in the requester's inventory."
                 ),
             ),
-        ] = "false",
+        ] = False,
     ) -> str:
         """Returns RHEL lifecycle information for systems in the requester's inventory.
 
@@ -317,10 +317,10 @@ class PlanningMCP(InsightsMCP):
         When the question is scoped to a specific RHEL major (or major/minor), set major (and optionally minor)
         so relevance is calculated only from systems on that version.
 
-        If the user wants only what is currently running, set include_related=false
+        If the user wants only what is currently running, set include_related=False
         (default, not needed to be specified).
 
-        If the user wants upgrade options or newer streams related to what they run today, set include_related=true and
+        If the user wants upgrade options or newer streams related to what they run today, set include_related=True and
         look at items where related=true as potential targets.
 
         Response guidance:

--- a/src/planning_mcp/tests/test_relevant_rhel_lifecycle.py
+++ b/src/planning_mcp/tests/test_relevant_rhel_lifecycle.py
@@ -219,7 +219,7 @@ class TestPlanningGetRelevantRhelLifecycle:
         with patch.object(planning_mcp_server.insights_client, "get") as mock_get:
             mock_get.return_value = mock_lifecycle_response
 
-            result = await planning_mcp_server.get_relevant_rhel_lifecycle(include_related=str(include_related))
+            result = await planning_mcp_server.get_relevant_rhel_lifecycle(include_related=include_related)
 
             mock_get.assert_called_once_with(
                 "relevant/lifecycle/rhel",


### PR DESCRIPTION
In src/planning_mcp/server.py, the get_relevant_rhel_lifecycle tool declared the include_related parameter with the wrong type:

```
# Before (incorrect)
include_related: Annotated[str, Field(default="false", ...)] = "false"
```
```
# After (correct)
include_related: Annotated[bool, Field(default=False, ...)] = False
```

MCP clients correctly send JSON booleans (true/false) per the MCP spec, but Pydantic rejected them because the schema expected a string, producing the string_type validation error.

The sibling tool `get_relevant_appstreams` in the same file and the underlying helper tools/relevant_rhel_lifecycle.py already used bool correctly — this was an isolated inconsistency in get_relevant_rhel_lifecycle.