### PR TITLE
Introduce GH token

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,4 +33,6 @@ jobs:
         run: make install-test-deps
 
       - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ indent-style = "space"
 [tool.pytest.ini_options]
 pythonpath = ["src", "."]
 testpaths = ["tests", "src"]
+markers = [
+    "integration: tests that call external APIs (e.g. GitHub API)",
+]
 
 [dependency-groups]
 dev = [

--- a/src/insights_mcp/server.py
+++ b/src/insights_mcp/server.py
@@ -338,6 +338,19 @@ def print_toolset_help_and_exit(args: argparse.Namespace):
         sys.exit(0)
 
 
+def _github_api_headers() -> dict[str, str]:
+    """Build headers for GitHub REST API requests.
+
+    Uses GITHUB_TOKEN or GH_TOKEN from the environment when available to avoid
+    unauthenticated rate limits (especially in CI).
+    """
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
 def extract_version_sha(version: str) -> str:
     """Extract the SHA component from a version string.
 
@@ -355,7 +368,11 @@ def get_latest_release_tag() -> str:
     """Get the latest release tag from github."""
     # https://github.com/RedHatInsights/insights-mcp/releases
     # rather use the api to get the latest release tag
-    response = requests.get("https://api.github.com/repos/RedHatInsights/insights-mcp/releases/latest", timeout=30)
+    response = requests.get(
+        "https://api.github.com/repos/RedHatInsights/insights-mcp/releases/latest",
+        headers=_github_api_headers(),
+        timeout=30,
+    )
     response.raise_for_status()
     return response.json()["tag_name"]
 
@@ -440,6 +457,7 @@ def get_mcp_version() -> str:
         # Use GitHub Compare API which is designed for comparing between tags/commits
         response = requests.get(
             f"https://api.github.com/repos/RedHatInsights/insights-mcp/compare/{__version__}...{latest_release_tag}",
+            headers=_github_api_headers(),
             timeout=30,
         )
         response.raise_for_status()

--- a/src/insights_mcp/tests/test_version_check.py
+++ b/src/insights_mcp/tests/test_version_check.py
@@ -5,7 +5,12 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from insights_mcp.server import extract_version_sha, get_latest_release_tag, get_mcp_version
+from insights_mcp.server import (
+    _github_api_headers,
+    extract_version_sha,
+    get_latest_release_tag,
+    get_mcp_version,
+)
 
 
 class TestExtractVersionSha:
@@ -104,6 +109,29 @@ def test_version_check_with_updates_available(mock_requests_get, mock_get_latest
             "https://api.github.com/repos/RedHatInsights/insights-mcp/compare/"
             "20250905-001953-16930107...20250905-072605-a8f7bd3a"
         ),
+        headers=_github_api_headers(),
+        timeout=30,
+    )
+
+
+@patch("insights_mcp.server.requests.get")
+def test_get_latest_release_tag_uses_github_token(mock_requests_get, monkeypatch):
+    """Test that GitHub API calls include auth headers when GITHUB_TOKEN is set."""
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"tag_name": "20250905-072605-a8f7bd3a"}
+    mock_requests_get.return_value = mock_response
+
+    latest_tag = get_latest_release_tag()
+
+    assert latest_tag == "20250905-072605-a8f7bd3a"
+    mock_requests_get.assert_called_once_with(
+        "https://api.github.com/repos/RedHatInsights/insights-mcp/releases/latest",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": "Bearer test-token",
+        },
         timeout=30,
     )
 


### PR DESCRIPTION
Uses the github token if set. Avoids rate limit problems especially in CI environments.