### PR TITLE
Indicate call failures (HMS-10703)

### DIFF
--- a/src/advisor_mcp/server.py
+++ b/src/advisor_mcp/server.py
@@ -8,6 +8,7 @@ from fastmcp.tools import Tool
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from insights_mcp.errors import InsightsApiError
 from insights_mcp.mcp import InsightsMCP
 
 
@@ -374,7 +375,9 @@ class AdvisorMCP(InsightsMCP):
                         tag_list.append(tag)
                     elif tag:
                         self.logger.error("Invalid tag format '%s', Required format: namespace/key=value", tag)
-                        return f"Error: Invalid tag format '{tag}', Required format: namespace/key=value"
+                        raise InsightsApiError(
+                            f"Error: Invalid tag format '{tag}', Required format: namespace/key=value"
+                        )
 
                 if tag_list:
                     params["tags"] = ",".join(tag_list)
@@ -384,7 +387,7 @@ class AdvisorMCP(InsightsMCP):
             return response
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error("Error: Failed to retrieve recommendations: %s", str(e))
-            return f"Error: Failed to retrieve recommendations: {str(e)}"
+            raise InsightsApiError(f"Error: Failed to retrieve recommendations: {str(e)}") from e
 
     async def get_rule_from_node_id(
         self,
@@ -408,7 +411,7 @@ class AdvisorMCP(InsightsMCP):
             return response
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error("Failed to retrieve recommendation for node ID %s: %s", node_id, str(e))
-            return f"Error: Failed to retrieve recommendation for node ID {node_id}: {str(e)}"
+            raise InsightsApiError(f"Error: Failed to retrieve recommendation for node ID {node_id}: {str(e)}") from e
 
     async def get_rule_details(
         self,
@@ -425,19 +428,19 @@ class AdvisorMCP(InsightsMCP):
             Standard call: {"rule_id": "xfs_with_md_raid_hang|XFS_WITH_MD_RAID_HANG_ISSUE_DEFAULT_KERNEL"}
         """
         if not rule_id or not isinstance(rule_id, str) or "|" not in rule_id:
-            return "Error: Recommendation ID must be a non-empty string in format rule_name|ERROR_KEY."
+            raise InsightsApiError("Error: Recommendation ID must be a non-empty string in format rule_name|ERROR_KEY.")
 
         # Basic sanitization for rule_id
         sanitized_rule_id = rule_id.strip()
         if not sanitized_rule_id:
-            return "Error: Recommendation ID cannot be empty."
+            raise InsightsApiError("Error: Recommendation ID cannot be empty.")
 
         try:
             response = await self.insights_client.get(f"rule/{sanitized_rule_id}/")
             return response
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error("Error: Failed to retrieve recommendation details for %s: %s", rule_id, str(e))
-            return f"Error: Failed to retrieve recommendation details for {rule_id}: {str(e)}"
+            raise InsightsApiError(f"Error: Failed to retrieve recommendation details for {rule_id}: {str(e)}") from e
 
     async def get_hosts_hitting_a_rule(
         self,
@@ -456,18 +459,18 @@ class AdvisorMCP(InsightsMCP):
             Standard call: {"rule_id": "xfs_with_md_raid_hang|XFS_WITH_MD_RAID_HANG_ISSUE_DEFAULT_KERNEL"}
         """
         if not rule_id or not isinstance(rule_id, str) or "|" not in rule_id:
-            return "Error: Recommendation ID must be a non-empty string."
+            raise InsightsApiError("Error: Recommendation ID must be a non-empty string.")
 
         sanitized_rule_id = rule_id.strip()
         if not sanitized_rule_id:
-            return "Error: Recommendation ID cannot be empty."
+            raise InsightsApiError("Error: Recommendation ID cannot be empty.")
 
         try:
             response = await self.insights_client.get(f"rule/{sanitized_rule_id}/systems/")
             return response
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error("Error: Failed to retrieve systems for recommendation %s: %s", rule_id, str(e))
-            return f"Error: Failed to retrieve systems for recommendation {rule_id}: {str(e)}"
+            raise InsightsApiError(f"Error: Failed to retrieve systems for recommendation {rule_id}: {str(e)}") from e
 
     async def get_hosts_details_for_rule(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
@@ -506,11 +509,11 @@ class AdvisorMCP(InsightsMCP):
             Combined filters: {"rule_id": "rule_id", "limit": 50, "offset": 20, "rhel_version": "8.9"}
         """
         if not rule_id or not isinstance(rule_id, str) or "|" not in rule_id:
-            return "Error: Recommendation ID must be a non-empty string."
+            raise InsightsApiError("Error: Recommendation ID must be a non-empty string.")
 
         sanitized_rule_id = rule_id.strip()
         if not sanitized_rule_id:
-            return "Error: Recommendation ID cannot be empty."
+            raise InsightsApiError("Error: Recommendation ID cannot be empty.")
 
         rhel_version_list = self._parse_string_list(rhel_version)
 
@@ -578,7 +581,9 @@ class AdvisorMCP(InsightsMCP):
                 )
                 valid_versions = ", ".join(sorted(valid_rhel_versions))
                 invalid_list = ", ".join(invalid_versions)
-                return f"Error: Invalid RHEL version(s) '{invalid_list}'. Valid versions are: {valid_versions}"
+                raise InsightsApiError(
+                    f"Error: Invalid RHEL version(s) '{invalid_list}'. Valid versions are: {valid_versions}"
+                )
 
         # Build query parameters
         params: dict[str, int | str] = {}
@@ -594,7 +599,9 @@ class AdvisorMCP(InsightsMCP):
             self.logger.error(
                 "Error: Failed to retrieve detailed system information for recommendation %s: %s", rule_id, str(e)
             )
-            return f"Error: Failed to retrieve detailed system information for recommendation {rule_id}: {str(e)}"
+            raise InsightsApiError(
+                f"Error: Failed to retrieve detailed system information for recommendation {rule_id}: {str(e)}"
+            ) from e
 
     async def get_rule_by_text_search(
         self,
@@ -611,14 +618,14 @@ class AdvisorMCP(InsightsMCP):
         """
         sanitized_text = text.strip()
         if not sanitized_text:
-            return "Error: Text search query must be a non-empty string."
+            raise InsightsApiError("Error: Text search query must be a non-empty string.")
 
         try:
             response = await self.insights_client.get("rule/", params={"text": sanitized_text})
             return response
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error("Error: Failed to retrieve recommendations for text search '%s': %s", text, str(e))
-            return f"Error: Failed to retrieve recommendations for text search {text}: {str(e)}"
+            raise InsightsApiError(f"Error: Failed to retrieve recommendations for text search {text}: {str(e)}") from e
 
     async def get_recommendations_stats(
         self,
@@ -674,7 +681,9 @@ class AdvisorMCP(InsightsMCP):
                         continue
                     if "/" not in tag_stripped or "=" not in tag_stripped:
                         self.logger.error("Invalid tag format '%s', expected namespace/key=value", tag_stripped)
-                        return f"Error: Invalid tag format '{tag_stripped}', expected namespace/key=value"
+                        raise InsightsApiError(
+                            f"Error: Invalid tag format '{tag_stripped}', expected namespace/key=value"
+                        )
                     tag_list.append(tag_stripped)
 
                 if tag_list:
@@ -685,7 +694,7 @@ class AdvisorMCP(InsightsMCP):
             return response
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error("Error: Failed to retrieve recommendations statistics: %s", str(e))
-            return f"Error: Failed to retrieve recommendations statistics: {str(e)}"
+            raise InsightsApiError(f"Error: Failed to retrieve recommendations statistics: {str(e)}") from e
 
 
 mcp_server = AdvisorMCP()

--- a/src/advisor_mcp/tests/test_get_active_rules.py
+++ b/src/advisor_mcp/tests/test_get_active_rules.py
@@ -2,8 +2,9 @@
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (  # pylint: disable=import-error
-    assert_api_error_result,
+    assert_api_error_message,
 )
 
 from .conftest import get_default_active_rules_params, setup_advisor_mock
@@ -213,11 +214,12 @@ class TestGetActiveRules:
 
         # Call the method with invalid tags (missing namespace/key=value format)
         params = get_default_active_rules_params(tags=["invalid-tag", "insights-client/group=valid-tag"])
-        result = await advisor_mcp_server.get_active_rules(**params)
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_active_rules(**params)
 
-        # Should return error message for invalid tag format
-        assert "Error: Invalid tag format 'invalid-tag'" in result
-        assert "Required format: namespace/key=value" in result
+        error_message = str(exc_info.value)
+        assert "Error: Invalid tag format 'invalid-tag'" in error_message
+        assert "Required format: namespace/key=value" in error_message
 
     # Pagination tests
 
@@ -289,13 +291,12 @@ class TestGetActiveRules:
 
         # Setup mocks with exception
         with setup_advisor_mock(advisor_mcp_server, advisor_mock_client, side_effect=exception):
-            # Call the method
             params = get_default_active_rules_params()
-            result = await advisor_mcp_server.get_active_rules(**params)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await advisor_mcp_server.get_active_rules(**params)
 
-            # Should return error message
-            assert_api_error_result(result, error_message)
-            assert f"Failed to retrieve recommendations: {error_message}" in result
+            assert_api_error_message(exc_info.value, error_message)
+            assert f"Failed to retrieve recommendations: {error_message}" in str(exc_info.value)
 
     # Parameter combination tests
     @pytest.mark.parametrize(

--- a/src/advisor_mcp/tests/test_get_hosts_details_for_rule.py
+++ b/src/advisor_mcp/tests/test_get_hosts_details_for_rule.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
+
 from .conftest import TEST_RHEL_VERSION, TEST_RULE_ID, get_default_hosts_details_params, setup_advisor_mock
 
 
@@ -153,11 +155,12 @@ class TestGetHostsDetailsForRule:
 
         # Call the method with invalid RHEL version
         params = get_default_hosts_details_params(rule_id=rule_id, rhel_version="invalid.version")
-        result = await advisor_mcp_server.get_hosts_details_for_rule(**params)
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_hosts_details_for_rule(**params)
 
-        # Should return error message
-        assert "Error: Invalid RHEL version(s) 'invalid.version'" in result
-        assert "Valid versions are:" in result
+        error_message = str(exc_info.value)
+        assert "Error: Invalid RHEL version(s) 'invalid.version'" in error_message
+        assert "Valid versions are:" in error_message
 
     @pytest.mark.parametrize(
         "rule_id, expected_error",
@@ -170,8 +173,9 @@ class TestGetHostsDetailsForRule:
     async def test_get_hosts_details_for_rule_invalid_rule_id(self, advisor_mcp_server, rule_id, expected_error):
         """Test get_hosts_details_for_rule with various invalid rule IDs."""
         params = get_default_hosts_details_params(rule_id=rule_id)
-        result = await advisor_mcp_server.get_hosts_details_for_rule(**params)
-        assert result == expected_error
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_hosts_details_for_rule(**params)
+        assert str(exc_info.value) == expected_error
 
     @pytest.mark.asyncio
     async def test_get_hosts_details_for_rule_api_error(self, advisor_mcp_server, advisor_mock_client):
@@ -180,13 +184,13 @@ class TestGetHostsDetailsForRule:
 
         # Setup mocks
         with setup_advisor_mock(advisor_mcp_server, advisor_mock_client, side_effect=Exception("API Error")):
-            # Call the method
             params = get_default_hosts_details_params(rule_id=rule_id)
-            result = await advisor_mcp_server.get_hosts_details_for_rule(**params)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await advisor_mcp_server.get_hosts_details_for_rule(**params)
 
-            # Should return error message
-            assert f"Failed to retrieve detailed system information for recommendation {rule_id}:" in result
-            assert "API Error" in result
+            error_message = str(exc_info.value)
+            assert f"Failed to retrieve detailed system information for recommendation {rule_id}:" in error_message
+            assert "API Error" in error_message
 
     @pytest.mark.asyncio
     async def test_get_hosts_details_for_rule_empty_response(self, advisor_mcp_server, advisor_mock_client):
@@ -207,10 +211,10 @@ class TestGetHostsDetailsForRule:
         """Test get_hosts_details_for_rule with whitespace-only rule ID."""
         # Call the method with whitespace-only rule_id
         params = get_default_hosts_details_params(rule_id="   ")
-        result = await advisor_mcp_server.get_hosts_details_for_rule(**params)
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_hosts_details_for_rule(**params)
 
-        # Should return error message
-        assert result == "Error: Recommendation ID must be a non-empty string."
+        assert str(exc_info.value) == "Error: Recommendation ID must be a non-empty string."
 
     @pytest.mark.parametrize(
         "exception, error_message",
@@ -229,13 +233,13 @@ class TestGetHostsDetailsForRule:
 
         # Setup mocks with exception
         with setup_advisor_mock(advisor_mcp_server, advisor_mock_client, side_effect=exception):
-            # Call the method
             params = get_default_hosts_details_params(rule_id=rule_id)
-            result = await advisor_mcp_server.get_hosts_details_for_rule(**params)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await advisor_mcp_server.get_hosts_details_for_rule(**params)
 
-            # Should return error message
-            assert f"Failed to retrieve detailed system information for recommendation {rule_id}:" in result
-            assert error_message in result
+            error_text = str(exc_info.value)
+            assert f"Failed to retrieve detailed system information for recommendation {rule_id}:" in error_text
+            assert error_message in error_text
 
     @pytest.mark.asyncio
     async def test_get_hosts_details_for_rule_valid_rhel_versions(
@@ -314,8 +318,9 @@ class TestGetHostsDetailsForRule:
 
         # Call the method with invalid RHEL versions
         params = get_default_hosts_details_params(rule_id=rule_id, rhel_version=invalid_versions)
-        result = await advisor_mcp_server.get_hosts_details_for_rule(**params)
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_hosts_details_for_rule(**params)
 
-        # Should return error message with all invalid versions
-        assert "Error: Invalid RHEL version(s) '5.9, 11.0, 9.99'" in result
-        assert "Valid versions are:" in result
+        error_message = str(exc_info.value)
+        assert "Error: Invalid RHEL version(s) '5.9, 11.0, 9.99'" in error_message
+        assert "Valid versions are:" in error_message

--- a/src/advisor_mcp/tests/test_get_hosts_hitting_a_rule.py
+++ b/src/advisor_mcp/tests/test_get_hosts_hitting_a_rule.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
+
 from .conftest import TEST_RULE_ID, setup_advisor_mock
 
 
@@ -42,17 +44,17 @@ class TestGetHostsHittingARule:
     @pytest.mark.asyncio
     async def test_get_hosts_hitting_a_rule_invalid_rule_id(self, advisor_mcp_server, rule_id, expected_error):
         """Test get_hosts_hitting_a_rule with various invalid rule IDs."""
-        result = await advisor_mcp_server.get_hosts_hitting_a_rule(rule_id=rule_id)
-        assert result == expected_error
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_hosts_hitting_a_rule(rule_id=rule_id)
+        assert str(exc_info.value) == expected_error
 
     @pytest.mark.asyncio
     async def test_get_hosts_hitting_a_rule_whitespace_rule_id(self, advisor_mcp_server):
         """Test get_hosts_hitting_a_rule with whitespace-only rule ID."""
-        # Call the method with whitespace-only rule_id
-        result = await advisor_mcp_server.get_hosts_hitting_a_rule(rule_id="   ")
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_hosts_hitting_a_rule(rule_id="   ")
 
-        # Should return error message
-        assert result == "Error: Recommendation ID must be a non-empty string."
+        assert str(exc_info.value) == "Error: Recommendation ID must be a non-empty string."
 
     @pytest.mark.asyncio
     async def test_get_hosts_hitting_a_rule_whitespace_handling(
@@ -76,12 +78,12 @@ class TestGetHostsHittingARule:
 
         # Setup mocks
         with setup_advisor_mock(advisor_mcp_server, advisor_mock_client, side_effect=Exception("API Error")):
-            # Call the method
-            result = await advisor_mcp_server.get_hosts_hitting_a_rule(rule_id=rule_id)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await advisor_mcp_server.get_hosts_hitting_a_rule(rule_id=rule_id)
 
-            # Should return error message
-            assert f"Failed to retrieve systems for recommendation {rule_id}:" in result
-            assert "API Error" in result
+            error_message = str(exc_info.value)
+            assert f"Failed to retrieve systems for recommendation {rule_id}:" in error_message
+            assert "API Error" in error_message
 
     @pytest.mark.asyncio
     async def test_get_hosts_hitting_a_rule_empty_response(self, advisor_mcp_server, advisor_mock_client):

--- a/src/advisor_mcp/tests/test_get_recommendations_stats.py
+++ b/src/advisor_mcp/tests/test_get_recommendations_stats.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
+
 from .conftest import setup_advisor_mock
 
 
@@ -97,11 +99,12 @@ class TestGetRecommendationsStats:
         """Test get_recommendations_stats with invalid tag format (should return error)."""
 
         # Call the method with invalid tags (missing namespace/key=value format)
-        result = await advisor_mcp_server.get_recommendations_stats(groups=None, tags=["invalid-tag-format"])
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_recommendations_stats(groups=None, tags=["invalid-tag-format"])
 
-        # Should return error message for invalid tag format
-        assert "Error: Invalid tag format 'invalid-tag-format'" in result
-        assert "expected namespace/key=value" in result
+        error_message = str(exc_info.value)
+        assert "Error: Invalid tag format 'invalid-tag-format'" in error_message
+        assert "expected namespace/key=value" in error_message
 
         # API should not be called when validation fails
         advisor_mock_client.get.assert_not_called()
@@ -112,12 +115,12 @@ class TestGetRecommendationsStats:
 
         # Setup mocks
         with setup_advisor_mock(advisor_mcp_server, advisor_mock_client, side_effect=Exception("API Error")):
-            # Call the method
-            result = await advisor_mcp_server.get_recommendations_stats(groups=None, tags=None)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await advisor_mcp_server.get_recommendations_stats(groups=None, tags=None)
 
-            # Should return error message
-            assert "Failed to retrieve recommendations statistics:" in result
-            assert "API Error" in result
+            error_message = str(exc_info.value)
+            assert "Failed to retrieve recommendations statistics:" in error_message
+            assert "API Error" in error_message
 
     @pytest.mark.asyncio
     async def test_get_recommendations_stats_empty_response(self, advisor_mcp_server, advisor_mock_client):

--- a/src/advisor_mcp/tests/test_get_rule_by_text_search.py
+++ b/src/advisor_mcp/tests/test_get_rule_by_text_search.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
+
 from .conftest import setup_advisor_mock
 
 
@@ -130,22 +132,22 @@ class TestGetRuleByTextSearch:
     @pytest.mark.asyncio
     async def test_get_rule_by_text_search_invalid_text(self, advisor_mcp_server, text, expected_error):
         """Test get_rule_by_text_search with various invalid text inputs."""
-        result = await advisor_mcp_server.get_rule_by_text_search(text=text)
-        assert result == expected_error
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_rule_by_text_search(text=text)
+        assert str(exc_info.value) == expected_error
 
     @pytest.mark.asyncio
     async def test_get_rule_by_text_search_api_error(self, advisor_mcp_server, advisor_mock_client):
         """Test get_rule_by_text_search when API returns error."""
         search_text = "test"
 
-        # Setup mocks
         with setup_advisor_mock(advisor_mcp_server, advisor_mock_client, side_effect=Exception("API Error")):
-            # Call the method
-            result = await advisor_mcp_server.get_rule_by_text_search(text=search_text)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await advisor_mcp_server.get_rule_by_text_search(text=search_text)
 
-            # Should return error message
-            assert f"Failed to retrieve recommendations for text search {search_text}:" in result
-            assert "API Error" in result
+            error_message = str(exc_info.value)
+            assert f"Failed to retrieve recommendations for text search {search_text}:" in error_message
+            assert "API Error" in error_message
 
     @pytest.mark.asyncio
     async def test_get_rule_by_text_search_empty_response(self, advisor_mcp_server, advisor_mock_client):

--- a/src/advisor_mcp/tests/test_get_rule_details.py
+++ b/src/advisor_mcp/tests/test_get_rule_details.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
+
 from .conftest import TEST_RULE_ID, setup_advisor_mock
 
 
@@ -73,31 +75,32 @@ class TestGetRuleDetails:
     @pytest.mark.asyncio
     async def test_get_rule_details_invalid_rule_id(self, advisor_mcp_server, rule_id, expected_error):
         """Test get_rule_details with various invalid rule IDs."""
-        result = await advisor_mcp_server.get_rule_details(rule_id=rule_id)
-        assert result == expected_error
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_rule_details(rule_id=rule_id)
+        assert str(exc_info.value) == expected_error
 
     @pytest.mark.asyncio
     async def test_get_rule_details_whitespace_rule_id(self, advisor_mcp_server):
         """Test get_rule_details with whitespace-only rule ID."""
-        # Call the method with whitespace-only rule_id
-        result = await advisor_mcp_server.get_rule_details(rule_id="   ")
+        with pytest.raises(InsightsApiError) as exc_info:
+            await advisor_mcp_server.get_rule_details(rule_id="   ")
 
-        # Should return error message
-        assert result == "Error: Recommendation ID must be a non-empty string in format rule_name|ERROR_KEY."
+        assert str(exc_info.value) == (
+            "Error: Recommendation ID must be a non-empty string in format rule_name|ERROR_KEY."
+        )
 
     @pytest.mark.asyncio
     async def test_get_rule_details_api_error(self, advisor_mcp_server, advisor_mock_client):
         """Test get_rule_details when API returns error."""
         rule_id = TEST_RULE_ID
 
-        # Setup mocks
         with setup_advisor_mock(advisor_mcp_server, advisor_mock_client, side_effect=Exception("API Error")):
-            # Call the method
-            result = await advisor_mcp_server.get_rule_details(rule_id=rule_id)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await advisor_mcp_server.get_rule_details(rule_id=rule_id)
 
-            # Should return error message
-            assert f"Failed to retrieve recommendation details for {rule_id}:" in result
-            assert "API Error" in result
+            error_message = str(exc_info.value)
+            assert f"Failed to retrieve recommendation details for {rule_id}:" in error_message
+            assert "API Error" in error_message
 
     @pytest.mark.asyncio
     async def test_get_rule_details_empty_response(self, advisor_mcp_server, advisor_mock_client):

--- a/src/advisor_mcp/tests/test_get_rule_from_node_id.py
+++ b/src/advisor_mcp/tests/test_get_rule_from_node_id.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
+
 from .conftest import TEST_NODE_ID, setup_advisor_mock
 
 
@@ -46,12 +48,12 @@ class TestGetRuleFromNodeId:
 
         # Setup mocks
         with setup_advisor_mock(advisor_mcp_server, advisor_mock_client, side_effect=Exception("Invalid node ID")):
-            # Call the method
-            result = await advisor_mcp_server.get_rule_from_node_id(node_id=node_id)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await advisor_mcp_server.get_rule_from_node_id(node_id=node_id)
 
-            # Should return error message
-            assert f"Failed to retrieve recommendation for node ID {node_id}:" in result
-            assert "Invalid node ID" in result
+            error_message = str(exc_info.value)
+            assert f"Failed to retrieve recommendation for node ID {node_id}:" in error_message
+            assert "Invalid node ID" in error_message
 
     @pytest.mark.asyncio
     async def test_get_rule_from_node_id_large_integer(
@@ -78,12 +80,12 @@ class TestGetRuleFromNodeId:
 
         # Setup mocks
         with setup_advisor_mock(advisor_mcp_server, advisor_mock_client, side_effect=Exception("API Error")):
-            # Call the method
-            result = await advisor_mcp_server.get_rule_from_node_id(node_id=node_id)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await advisor_mcp_server.get_rule_from_node_id(node_id=node_id)
 
-            # Should return error message
-            assert f"Failed to retrieve recommendation for node ID {node_id}:" in result
-            assert "API Error" in result
+            error_message = str(exc_info.value)
+            assert f"Failed to retrieve recommendation for node ID {node_id}:" in error_message
+            assert "API Error" in error_message
 
     @pytest.mark.asyncio
     async def test_get_rule_from_node_id_empty_response(self, advisor_mcp_server, advisor_mock_client):

--- a/src/content_sources_mcp/server.py
+++ b/src/content_sources_mcp/server.py
@@ -4,7 +4,6 @@ MCP server for content sources data via Red Hat Insights API.
 Provides tools to get repository information from content sources.
 """
 
-import json
 import logging
 from typing import Annotated, Any, Optional
 
@@ -13,6 +12,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from insights_mcp.mcp import InsightsMCP
+from tools.common import run_insights_tool_request
 
 
 class ContentSourcesMCP(InsightsMCP):
@@ -112,13 +112,10 @@ class ContentSourcesMCP(InsightsMCP):
         params["limit"] = limit
         params["offset"] = offset
 
-        try:
-            response = await self.insights_client.get("repositories/", params=params)
-            if isinstance(response, str):
-                return response
-            return json.dumps(response)
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error listing repositories: {str(e)}"
+        return await run_insights_tool_request(
+            self.insights_client.get("repositories/", params=params),
+            error_message=lambda exc: f"Error listing repositories: {exc}",
+        )
 
 
 mcp = ContentSourcesMCP()

--- a/src/image_builder_mcp/server.py
+++ b/src/image_builder_mcp/server.py
@@ -11,6 +11,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from insights_mcp.client import InsightsClient
+from insights_mcp.errors import InsightsApiError
 from insights_mcp.mcp import InsightsMCP
 from tools import OpenAPIReducer
 
@@ -202,8 +203,10 @@ class ImageBuilderMCP(InsightsMCP):
         try:
             distributions = await self.insights_client.get("distributions")
             return json.dumps(distributions)
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error getting distributions: {str(e)}"
+        except InsightsApiError:
+            raise
+        except Exception as e:
+            raise InsightsApiError(f"Error getting distributions: {str(e)}") from e
 
     def get_openapi_synchronous(self) -> str:
         """
@@ -235,9 +238,10 @@ class ImageBuilderMCP(InsightsMCP):
         """
         try:
             response = await self.insights_client.post(f"blueprints/{blueprint_uuid}/compose")
-        # avoid crashing the server so we'll stick to the broad exception catch
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error: {str(e)} in blueprint_compose {blueprint_uuid}"
+        except InsightsApiError:
+            raise
+        except Exception as e:
+            raise InsightsApiError(f"Error: {str(e)} in blueprint_compose {blueprint_uuid}") from e
 
         if isinstance(response, str):
             return response
@@ -248,7 +252,7 @@ class ImageBuilderMCP(InsightsMCP):
         build_ids_str: list[str] = []
 
         if isinstance(response, dict):
-            return (
+            raise InsightsApiError(
                 f"Error: the response of blueprint_compose is a dict. This is not expected. "
                 f"Response: {json.dumps(response)}"
             )
@@ -304,9 +308,10 @@ class ImageBuilderMCP(InsightsMCP):
                     self.logger.warning("OpenAPI reduction failed: %s", reduce_err)
                     return json.dumps(response)
             return json.dumps(response)
-        # avoid crashing the server so we'll stick to the broad exception catch
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error: {str(e)}"
+        except InsightsApiError:
+            raise
+        except Exception as e:
+            raise InsightsApiError(str(e)) from e
 
     async def get_org_id(self) -> str:
         """Get the organization ID for RHEL image registration/subscription.
@@ -325,9 +330,11 @@ class ImageBuilderMCP(InsightsMCP):
             org_id = await self.insights_client.get_org_id()
             if org_id:
                 return org_id
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error: {str(e)}"
-        return "Error: No organization ID found"
+        except InsightsApiError:
+            raise
+        except Exception as e:
+            raise InsightsApiError(str(e)) from e
+        raise InsightsApiError("Error: No organization ID found")
 
     async def create_blueprint(
         self,
@@ -407,15 +414,16 @@ class ImageBuilderMCP(InsightsMCP):
                 data["description"] = "\n".join(filter(None, desc_parts))
             # TBD: programmatically check against openapi
             response = await self.insights_client.post("blueprints", json=data)
-        # avoid crashing the server so we'll stick to the broad exception catch
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error: {str(e)}"
+        except InsightsApiError:
+            raise
+        except Exception as e:
+            raise InsightsApiError(str(e)) from e
 
         if isinstance(response, str):
             return response
 
         if isinstance(response, list):
-            return (
+            raise InsightsApiError(
                 "Error: the response of blueprint creation is a list. This is not expected. "
                 f"Response: {json.dumps(response)}"
             )
@@ -452,15 +460,17 @@ class ImageBuilderMCP(InsightsMCP):
                     desc_parts = [data.get("description", ""), WATERMARK_UPDATED]
                     data["description"] = "\n".join(filter(None, desc_parts))
             response = await self.insights_client.put(f"blueprints/{blueprint_uuid}", json=data)
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error: {str(e)}"
+        except InsightsApiError:
+            raise
+        except Exception as e:
+            raise InsightsApiError(str(e)) from e
 
         # Normalize response handling similar to create_blueprint
         if isinstance(response, str):
             return response
 
         if isinstance(response, list):
-            return (
+            raise InsightsApiError(
                 "Error: the response of blueprint update is a list. This is not expected. "
                 f"Response: {json.dumps(response)}"
             )
@@ -509,7 +519,7 @@ class ImageBuilderMCP(InsightsMCP):
                 return response
 
             if isinstance(response, list):
-                return (
+                raise InsightsApiError(
                     "Error: the response of get_blueprints is a list. This is not expected. "
                     f"Response: {json.dumps(response)}"
                 )
@@ -536,9 +546,10 @@ class ImageBuilderMCP(InsightsMCP):
             intro = "[INSTRUCTION] Use the UI_URL to link to the blueprint\n"
             intro += self.paging_reminder
             return f"{intro}\n{json.dumps(ret)}"
-        # avoid crashing the server so we'll stick to the broad exception catch
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error: {str(e)}"
+        except InsightsApiError:
+            raise
+        except Exception as e:
+            raise InsightsApiError(str(e)) from e
 
     async def get_blueprint_details(
         self, blueprint_identifier: Annotated[str, Field(description="The UUID, name or reply_id to query")]
@@ -554,7 +565,7 @@ class ImageBuilderMCP(InsightsMCP):
             Exception: If the image-builder connection fails.
         """
         if not blueprint_identifier:
-            return "Error: a blueprint identifier is required"
+            raise InsightsApiError("Error: a blueprint identifier is required")
 
         try:
             # If the identifier looks like a UUID, use it directly
@@ -568,10 +579,11 @@ class ImageBuilderMCP(InsightsMCP):
             ret += "please use the UUID from get_blueprints\n"
             ret += "[INSTRUCTION] retry calling get_blueprints\n\n"
             ret += f"[ANSWER] {blueprint_identifier} is not a valid blueprint identifier"
-            return ret
-        # avoid crashing the server so we'll stick to the broad exception catch
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error: {str(e)}"
+            raise InsightsApiError(ret)
+        except InsightsApiError:
+            raise
+        except Exception as e:
+            raise InsightsApiError(str(e)) from e
 
     def _create_compose_data(self, compose: dict, reply_id: int, client: InsightsClient) -> dict:
         """Create compose data dictionary with blueprint URL."""
@@ -648,7 +660,7 @@ class ImageBuilderMCP(InsightsMCP):
                 return response
 
             if isinstance(response, list):
-                return (
+                raise InsightsApiError(
                     f"Error: the response of get_composes is a list. This is not expected. "
                     f"Response: {json.dumps(response)}"
                 )
@@ -672,9 +684,10 @@ class ImageBuilderMCP(InsightsMCP):
             intro += "[ANSWER]\n"
             return f"{intro}\n{json.dumps(ret)}"
 
-        # avoid crashing the server so we'll stick to the broad exception catch
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error: {str(e)}"
+        except InsightsApiError:
+            raise
+        except Exception as e:
+            raise InsightsApiError(str(e)) from e
 
     # pylint: disable=too-many-return-statements
     async def get_compose_details(
@@ -700,7 +713,7 @@ class ImageBuilderMCP(InsightsMCP):
             - Artifact details
         """
         if not compose_identifier:
-            return "Error: Compose UUID is required"
+            raise InsightsApiError("Error: Compose UUID is required")
 
         try:
             # If the identifier looks like a UUID, use it directly
@@ -716,7 +729,7 @@ class ImageBuilderMCP(InsightsMCP):
                         compose_identifier,
                         json.dumps(response),
                     )
-                    return f"Error: Unexpected list response for {compose_identifier}"
+                    raise InsightsApiError(f"Error: Unexpected list response for {compose_identifier}")
                 response["compose_uuid"] = compose_identifier
             else:
                 ret = (
@@ -725,7 +738,7 @@ class ImageBuilderMCP(InsightsMCP):
                 )
                 ret += "[INSTRUCTION] retry calling get_composes\n\n"
                 ret += f"[ANSWER] {compose_identifier} is not a valid compose identifier"
-                return ret
+                raise InsightsApiError(ret)
 
             intro = ""
             download_url = response.get("image_status", {}).get("upload_status", {}).get("options", {}).get("url")
@@ -771,9 +784,10 @@ gcloud compute images create {image_name}-copy --source-image-project red-hat-im
             # else depends on the status and the target if it can be downloaded
 
             return f"{intro}{json.dumps(response)}"
-        # avoid crashing the server so we'll stick to the broad exception catch
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error: {e}"
+        except InsightsApiError:
+            raise
+        except Exception as e:
+            raise InsightsApiError(str(e)) from e
 
 
 mcp_server = ImageBuilderMCP()

--- a/src/image_builder_mcp/tests/test_blueprint_compose.py
+++ b/src/image_builder_mcp/tests/test_blueprint_compose.py
@@ -2,9 +2,10 @@
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
     TEST_BLUEPRINT_UUID,
-    assert_api_error_result,
+    assert_api_error_message,
     assert_instruction_in_result,
 )
 
@@ -78,11 +79,11 @@ class TestBlueprintCompose:
             imagebuilder_mcp_server, imagebuilder_mock_client, side_effect=Exception("API Error")
         ):
             # Call the method
-            result = await imagebuilder_mcp_server.blueprint_compose(blueprint_uuid=blueprint_uuid)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.blueprint_compose(blueprint_uuid=blueprint_uuid)
 
-            # Should return error message
-            assert_api_error_result(result)
-            assert blueprint_uuid in result
+            assert_api_error_message(exc_info.value)
+            assert blueprint_uuid in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_blueprint_compose_unexpected_dict_response(self, imagebuilder_mcp_server, imagebuilder_mock_client):
@@ -93,10 +94,10 @@ class TestBlueprintCompose:
         # Return dict instead of list (unexpected)
         with setup_imagebuilder_mock(imagebuilder_mcp_server, imagebuilder_mock_client, {"error": "Some error"}):
             # Call the method
-            result = await imagebuilder_mcp_server.blueprint_compose(blueprint_uuid=blueprint_uuid)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.blueprint_compose(blueprint_uuid=blueprint_uuid)
 
-            # Should return error message about unexpected dict response
-            assert "Error: the response of blueprint_compose is a dict" in result
+            assert "Error: the response of blueprint_compose is a dict" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_blueprint_compose_invalid_build_object(self, imagebuilder_mcp_server, imagebuilder_mock_client):

--- a/src/image_builder_mcp/tests/test_create_blueprint.py
+++ b/src/image_builder_mcp/tests/test_create_blueprint.py
@@ -2,10 +2,11 @@
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
     TEST_BLUEPRINT_UUID,
     TEST_CLIENT_ID,
-    assert_api_error_result,
+    assert_api_error_message,
     assert_instruction_in_result,
 )
 
@@ -90,10 +91,10 @@ class TestCreateBlueprint:
             imagebuilder_mcp_server, imagebuilder_mock_client, side_effect=Exception("API Error")
         ):
             # Call the method
-            result = await imagebuilder_mcp_server.create_blueprint(data=mock_blueprint_data)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.create_blueprint(data=mock_blueprint_data)
 
-            # Should return error message
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_create_blueprint_unexpected_list_response(
@@ -104,7 +105,7 @@ class TestCreateBlueprint:
         list_response = [{"id": "test-id"}]
         with setup_imagebuilder_mock(imagebuilder_mcp_server, imagebuilder_mock_client, list_response):
             # Call the method
-            result = await imagebuilder_mcp_server.create_blueprint(data=mock_blueprint_data)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.create_blueprint(data=mock_blueprint_data)
 
-            # Should return error message about unexpected list response
-            assert "Error: the response of blueprint creation is a list" in result
+            assert "Error: the response of blueprint creation is a list" in str(exc_info.value)

--- a/src/image_builder_mcp/tests/test_get_blueprint_details.py
+++ b/src/image_builder_mcp/tests/test_get_blueprint_details.py
@@ -4,9 +4,10 @@ import json
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
     TEST_BLUEPRINT_UUID,
-    assert_api_error_result,
+    assert_api_error_message,
 )
 
 from .conftest import setup_imagebuilder_mock
@@ -57,21 +58,22 @@ class TestGetBlueprintDetails:
         # Setup mocks
         with setup_imagebuilder_mock(imagebuilder_mcp_server, imagebuilder_mock_client, [{"id": "test-id"}]):
             # Call the method
-            result = await imagebuilder_mcp_server.get_blueprint_details(blueprint_identifier=invalid_uuid)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.get_blueprint_details(blueprint_identifier=invalid_uuid)
 
-            # Should return error message about invalid identifier
-            assert "[INSTRUCTION] Error:" in result
-            assert "is not a valid blueprint identifier" in result
-            assert "please use the UUID from get_blueprints" in result
+            error_message = str(exc_info.value)
+            assert "[INSTRUCTION] Error:" in error_message
+            assert "is not a valid blueprint identifier" in error_message
+            assert "please use the UUID from get_blueprints" in error_message
 
     @pytest.mark.asyncio
     async def test_get_blueprint_details_empty_identifier(self, imagebuilder_mcp_server):
         """Test get_blueprint_details with empty identifier."""
         # Call the method with empty identifier
-        result = await imagebuilder_mcp_server.get_blueprint_details(blueprint_identifier="")
+        with pytest.raises(InsightsApiError) as exc_info:
+            await imagebuilder_mcp_server.get_blueprint_details(blueprint_identifier="")
 
-        # Should return error message
-        assert result == "Error: a blueprint identifier is required"
+        assert str(exc_info.value) == "Error: a blueprint identifier is required"
 
     @pytest.mark.asyncio
     async def test_get_blueprint_details_api_error(self, imagebuilder_mcp_server, imagebuilder_mock_client):
@@ -83,10 +85,10 @@ class TestGetBlueprintDetails:
             imagebuilder_mcp_server, imagebuilder_mock_client, side_effect=Exception("API Error")
         ):
             # Call the method
-            result = await imagebuilder_mcp_server.get_blueprint_details(blueprint_identifier=blueprint_uuid)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.get_blueprint_details(blueprint_identifier=blueprint_uuid)
 
-            # Should return error message
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_get_blueprint_details_unexpected_list_response(

--- a/src/image_builder_mcp/tests/test_get_blueprints.py
+++ b/src/image_builder_mcp/tests/test_get_blueprints.py
@@ -4,6 +4,8 @@ import json
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
+
 from .conftest import setup_imagebuilder_mock
 
 
@@ -198,10 +200,10 @@ class TestGetBlueprints:
             imagebuilder_mcp_server, imagebuilder_mock_client, side_effect=Exception("API Error")
         ):
             # Call the method
-            result = await imagebuilder_mcp_server.get_blueprints(limit=7, offset=0, search_string="")
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.get_blueprints(limit=7, offset=0, search_string="")
 
-            # Should return error message
-            assert result.startswith("Error: API Error")
+            assert str(exc_info.value).startswith("Error: API Error") or "API Error" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_get_blueprints_null_search_string_handling(

--- a/src/image_builder_mcp/tests/test_get_compose_details.py
+++ b/src/image_builder_mcp/tests/test_get_compose_details.py
@@ -4,9 +4,10 @@ import json
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
     TEST_BLUEPRINT_UUID,
-    assert_api_error_result,
+    assert_api_error_message,
 )
 
 from .conftest import setup_imagebuilder_mock
@@ -107,21 +108,22 @@ class TestGetComposeDetails:
         # Setup mocks
         with setup_imagebuilder_mock(imagebuilder_mcp_server, imagebuilder_mock_client, [{"id": "test-id"}]):
             # Call the method
-            result = await imagebuilder_mcp_server.get_compose_details(compose_identifier=invalid_uuid)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.get_compose_details(compose_identifier=invalid_uuid)
 
-            # Should return error message about invalid identifier
-            assert "[INSTRUCTION] Error:" in result
-            assert "is not a valid compose identifier" in result
-            assert "please use the UUID from get_composes" in result
+            error_message = str(exc_info.value)
+            assert "[INSTRUCTION] Error:" in error_message
+            assert "is not a valid compose identifier" in error_message
+            assert "please use the UUID from get_composes" in error_message
 
     @pytest.mark.asyncio
     async def test_get_compose_details_empty_identifier(self, imagebuilder_mcp_server):
         """Test get_compose_details with empty identifier."""
         # Call the method with empty identifier
-        result = await imagebuilder_mcp_server.get_compose_details(compose_identifier="")
+        with pytest.raises(InsightsApiError) as exc_info:
+            await imagebuilder_mcp_server.get_compose_details(compose_identifier="")
 
-        # Should return error message
-        assert result == "Error: Compose UUID is required"
+        assert str(exc_info.value) == "Error: Compose UUID is required"
 
     @pytest.mark.asyncio
     async def test_get_compose_details_api_error(self, imagebuilder_mcp_server, imagebuilder_mock_client):
@@ -133,10 +135,10 @@ class TestGetComposeDetails:
             imagebuilder_mcp_server, imagebuilder_mock_client, side_effect=Exception("API Error")
         ):
             # Call the method
-            result = await imagebuilder_mcp_server.get_compose_details(compose_identifier=compose_uuid)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.get_compose_details(compose_identifier=compose_uuid)
 
-            # Should return error message
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_get_compose_details_unexpected_list_response(
@@ -148,7 +150,7 @@ class TestGetComposeDetails:
         # Setup mocks
         with setup_imagebuilder_mock(imagebuilder_mcp_server, imagebuilder_mock_client, [{"id": "test-id"}]):
             # Call the method
-            result = await imagebuilder_mcp_server.get_compose_details(compose_identifier=compose_uuid)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.get_compose_details(compose_identifier=compose_uuid)
 
-            # Should handle unexpected list response gracefully
-            assert f"Error: Unexpected list response for {compose_uuid}" in result
+            assert f"Error: Unexpected list response for {compose_uuid}" in str(exc_info.value)

--- a/src/image_builder_mcp/tests/test_get_composes.py
+++ b/src/image_builder_mcp/tests/test_get_composes.py
@@ -4,9 +4,10 @@ import json
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
     TEST_BLUEPRINT_UUID,
-    assert_api_error_result,
+    assert_api_error_message,
     assert_empty_response,
     assert_instruction_in_result,
 )
@@ -155,10 +156,10 @@ class TestGetComposes:
             imagebuilder_mcp_server, imagebuilder_mock_client, side_effect=Exception("API Error")
         ):
             # Call the method
-            result = await imagebuilder_mcp_server.get_composes(limit=7, offset=0, search_string="")
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.get_composes(limit=7, offset=0, search_string="")
 
-            # Should return error message
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_get_composes_zero_limit_uses_default(

--- a/src/image_builder_mcp/tests/test_get_distributions.py
+++ b/src/image_builder_mcp/tests/test_get_distributions.py
@@ -4,6 +4,8 @@ import json
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
+
 from .conftest import setup_imagebuilder_mock
 
 
@@ -73,20 +75,21 @@ class TestGetDistributions:
             imagebuilder_mcp_server, imagebuilder_mock_client, side_effect=Exception("API Error")
         ):
             # Call the method
-            result = await imagebuilder_mcp_server.get_distributions()
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.get_distributions()
 
-            # Should return error message
-            assert result.startswith("Error getting distributions: API Error")
+            assert str(exc_info.value).startswith("Error getting distributions: API Error")
 
     @pytest.mark.asyncio
     async def test_get_distributions_auth_error(self, imagebuilder_mcp_server):
         """Test get_distributions when authentication fails."""
         # Call the method
-        result = await imagebuilder_mcp_server.get_distributions()
+        with pytest.raises(InsightsApiError) as exc_info:
+            await imagebuilder_mcp_server.get_distributions()
 
-        # Should return authentication error
-        assert "[INSTRUCTION] There seems to be a problem with the request." in result
-        assert "authentication problem" in result
+        error_message = str(exc_info.value)
+        assert "[INSTRUCTION] There seems to be a problem with the request." in error_message
+        assert "authentication problem" in error_message
 
     @pytest.mark.asyncio
     async def test_get_distributions_no_parameters(

--- a/src/image_builder_mcp/tests/test_get_openapi.py
+++ b/src/image_builder_mcp/tests/test_get_openapi.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 
 import pytest
 
-from tests.conftest import assert_api_error_result
+from insights_mcp.errors import InsightsApiError
+from tests.conftest import assert_api_error_message
 
 
 class TestGetOpenAPI:
@@ -69,10 +70,10 @@ class TestGetOpenAPI:
             mock_get.side_effect = Exception("API Error")
 
             # Call the method
-            result = await imagebuilder_mcp_server.get_openapi(endpoints="GET:/blueprints")
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.get_openapi(endpoints="GET:/blueprints")
 
-            # Should return error message
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_get_openapi_reduces_by_endpoints(self, imagebuilder_mcp_server, mock_openapi_response):

--- a/src/image_builder_mcp/tests/test_update_blueprint.py
+++ b/src/image_builder_mcp/tests/test_update_blueprint.py
@@ -2,9 +2,10 @@
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
     TEST_BLUEPRINT_UUID,
-    assert_api_error_result,
+    assert_api_error_message,
     assert_instruction_in_result,
 )
 
@@ -115,9 +116,9 @@ class TestUpdateBlueprint:
             imagebuilder_mcp_server, imagebuilder_mock_client, side_effect=Exception("API Error")
         ):
             # Call the method
-            result = await imagebuilder_mcp_server.update_blueprint(
-                blueprint_uuid=TEST_BLUEPRINT_UUID, data=mock_blueprint_data
-            )
+            with pytest.raises(InsightsApiError) as exc_info:
+                await imagebuilder_mcp_server.update_blueprint(
+                    blueprint_uuid=TEST_BLUEPRINT_UUID, data=mock_blueprint_data
+                )
 
-            # Should return error message
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)

--- a/src/insights_mcp/client.py
+++ b/src/insights_mcp/client.py
@@ -37,6 +37,7 @@ from insights_mcp.config import (
     OAUTH_ENABLED,
     SSO_TOKEN_ENDPOINT,
 )
+from insights_mcp.errors import InsightsApiError
 from insights_mcp.session_cache import SessionCache
 
 from . import __version__
@@ -87,7 +88,10 @@ class InsightsClientBase(httpx.AsyncClient):
             **kwargs: Keyword arguments for the HTTP method
 
         Returns:
-            JSON response data or error information
+            JSON response data or plain-text body on success
+
+        Raises:
+            InsightsApiError: If the HTTP request fails or an unhandled error occurs
         """
         try:
             self.logger.debug(
@@ -122,10 +126,9 @@ class InsightsClientBase(httpx.AsyncClient):
             self.logger.debug("JSONDecodeError: %s", e)
             return response.content.decode("utf-8")
         except httpx.HTTPStatusError as e:
-            content = self.get_error_message(e)
-            return content
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            return {"Unhandled error": str(exc)}
+            raise InsightsApiError(self.get_error_message(e)) from e
+        except Exception as exc:
+            raise InsightsApiError(str(exc)) from exc
 
     def get_error_message(self, e: httpx.HTTPStatusError) -> str:
         """Generate appropriate error message based on HTTP status code.
@@ -451,7 +454,7 @@ class InsightsOAuth2Client(InsightsClientBase, AsyncOAuth2Client):
             JSON response data or error information
         """
         if not self.oauth_enabled and self.refresh_token is None and self.client_secret is None:
-            return self.no_auth_error(ValueError("Client not authenticated"))
+            raise InsightsApiError(self.no_auth_error(ValueError("Client not authenticated")))
 
         await self.refresh_auth()
 
@@ -1513,15 +1516,17 @@ class InsightsClient:  # pylint: disable=too-many-instance-attributes
             **kwargs: Additional arguments for the HTTP request
 
         Returns:
-            JSON response data or error information
+            JSON response data or plain-text body on success
+
+        Raises:
+            InsightsApiError: If authentication fails or the API request fails
         """
         try:
             client = self.client_noauth if noauth else self.client
             url = f"{self.insights_base_url}/{self.api_path}/{endpoint}"
             return await client.make_request(client.get, url=url, params=params, **kwargs)
         except ValueError as e:
-            # Authentication or validation error - return as string for MCP client
-            return str(e)
+            raise InsightsApiError(str(e)) from e
 
     async def post(
         self,
@@ -1539,15 +1544,17 @@ class InsightsClient:  # pylint: disable=too-many-instance-attributes
             **kwargs: Additional arguments for the HTTP request
 
         Returns:
-            JSON response data or error information
+            JSON response data or plain-text body on success
+
+        Raises:
+            InsightsApiError: If authentication fails or the API request fails
         """
         try:
             client = self.client_noauth if noauth else self.client
             url = f"{self.insights_base_url}/{self.api_path}/{endpoint}"
             return await client.make_request(client.post, url=url, json=json, **kwargs)
         except ValueError as e:
-            # Authentication or validation error - return as string for MCP client
-            return str(e)
+            raise InsightsApiError(str(e)) from e
 
     async def put(
         self,
@@ -1565,12 +1572,14 @@ class InsightsClient:  # pylint: disable=too-many-instance-attributes
             **kwargs: Additional arguments for the HTTP request
 
         Returns:
-            JSON response data or error information
+            JSON response data or plain-text body on success
+
+        Raises:
+            InsightsApiError: If authentication fails or the API request fails
         """
         try:
             client = self.client_noauth if noauth else self.client
             url = f"{self.insights_base_url}/{self.api_path}/{endpoint}"
             return await client.make_request(client.put, url=url, json=json, **kwargs)
         except ValueError as e:
-            # Authentication or validation error - return as string for MCP client
-            return str(e)
+            raise InsightsApiError(str(e)) from e

--- a/src/insights_mcp/errors.py
+++ b/src/insights_mcp/errors.py
@@ -1,0 +1,11 @@
+"""Shared exception types for Insights MCP."""
+
+from fastmcp.exceptions import ToolError
+
+
+class InsightsApiError(ToolError):
+    """Raised when an Insights API call or auth setup fails.
+
+    Subclassing ``ToolError`` ensures FastMCP sets ``isError: true`` on the
+    MCP ``CallToolResult`` while preserving the formatted error message for agents.
+    """

--- a/src/planning_mcp/tests/test_appstreams.py
+++ b/src/planning_mcp/tests/test_appstreams.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 
 import pytest
 
-from tests.conftest import assert_api_error_result
+from insights_mcp.errors import InsightsApiError
+from tests.conftest import assert_api_error_message
 
 
 class TestPlanningGetAppstreamsLifecycle:
@@ -257,12 +258,13 @@ class TestPlanningGetAppstreamsLifecycle:
         planning_mcp_server,
     ):
         """Invalid mode should surface as a standard API error string."""
-        result = await planning_mcp_server.get_appstreams_lifecycle(
-            mode="0",
-            application_stream_name="Node",
-        )
+        with pytest.raises(InsightsApiError) as exc_info:
+            await planning_mcp_server.get_appstreams_lifecycle(
+                mode="0",
+                application_stream_name="Node",
+            )
 
-        assert_api_error_result(result)
+        assert_api_error_message(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_accepts_string_major(

--- a/src/planning_mcp/tests/test_relevant_appstreams.py
+++ b/src/planning_mcp/tests/test_relevant_appstreams.py
@@ -6,8 +6,9 @@ from unittest.mock import patch
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
-    assert_api_error_result,
+    assert_api_error_message,
 )
 
 
@@ -237,19 +238,20 @@ class TestPlanningGetRelevantAppstreams:
         planning_mcp_server,
     ):
         """Test that providing minor without major returns an error."""
-        result = await planning_mcp_server.get_relevant_appstreams(minor="2")
+        with pytest.raises(InsightsApiError) as exc_info:
+            await planning_mcp_server.get_relevant_appstreams(minor="2")
 
-        # The error should be returned as a string, not raised
-        assert "Error: API Error" in result
-        assert "The 'minor' parameter requires 'major' to be specified" in result
+        error_message = str(exc_info.value)
+        assert "Error: API Error" in error_message
+        assert "The 'minor' parameter requires 'major' to be specified" in error_message
 
     @pytest.mark.asyncio
     async def test_get_relevant_appstreams_api_error(self, planning_mcp_server):
         """Test get_relevant_appstreams when backend raises an API error."""
         with patch.object(planning_mcp_server.insights_client, "get") as mock_get:
-            mock_get.side_effect = Exception("Backend unavailable")
+            mock_get.side_effect = RuntimeError("Backend unavailable")
 
-            result = await planning_mcp_server.get_relevant_appstreams()
+            with pytest.raises(InsightsApiError) as exc_info:
+                await planning_mcp_server.get_relevant_appstreams()
 
-            # Reuse common helper to validate error formatting
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)

--- a/src/planning_mcp/tests/test_relevant_rhel_lifecycle.py
+++ b/src/planning_mcp/tests/test_relevant_rhel_lifecycle.py
@@ -6,8 +6,9 @@ from unittest.mock import patch
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
-    assert_api_error_result,
+    assert_api_error_message,
 )
 
 
@@ -267,19 +268,20 @@ class TestPlanningGetRelevantRhelLifecycle:
         planning_mcp_server,
     ):
         """Test that providing minor without major returns an error."""
-        result = await planning_mcp_server.get_relevant_rhel_lifecycle(minor="2")
+        with pytest.raises(InsightsApiError) as exc_info:
+            await planning_mcp_server.get_relevant_rhel_lifecycle(minor="2")
 
-        # The error should be returned as a string, not raised
-        assert "Error: API Error" in result
-        assert "The 'minor' parameter requires 'major' to be specified" in result
+        error_message = str(exc_info.value)
+        assert "Error: API Error" in error_message
+        assert "The 'minor' parameter requires 'major' to be specified" in error_message
 
     @pytest.mark.asyncio
     async def test_get_relevant_rhel_lifecycle_api_error(self, planning_mcp_server):
         """Test get_relevant_rhel_lifecycle when backend raises an API error."""
         with patch.object(planning_mcp_server.insights_client, "get") as mock_get:
-            mock_get.side_effect = Exception("Backend unavailable")
+            mock_get.side_effect = RuntimeError("Backend unavailable")
 
-            result = await planning_mcp_server.get_relevant_rhel_lifecycle()
+            with pytest.raises(InsightsApiError) as exc_info:
+                await planning_mcp_server.get_relevant_rhel_lifecycle()
 
-            # Reuse common helper to validate error formatting
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)

--- a/src/planning_mcp/tests/test_relevant_upcoming.py
+++ b/src/planning_mcp/tests/test_relevant_upcoming.py
@@ -6,8 +6,9 @@ from unittest.mock import patch
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
-    assert_api_error_result,
+    assert_api_error_message,
 )
 
 
@@ -218,19 +219,20 @@ class TestPlanningGetRelevantUpcoming:
         planning_mcp_server,
     ):
         """Test that providing minor without major returns an error."""
-        result = await planning_mcp_server.get_relevant_upcoming(minor="2")
+        with pytest.raises(InsightsApiError) as exc_info:
+            await planning_mcp_server.get_relevant_upcoming(minor="2")
 
-        # The error should be returned as a string, not raised
-        assert "Error: API Error" in result
-        assert "The 'minor' parameter requires 'major' to be specified" in result
+        error_message = str(exc_info.value)
+        assert "Error: API Error" in error_message
+        assert "The 'minor' parameter requires 'major' to be specified" in error_message
 
     @pytest.mark.asyncio
     async def test_get_relevant_upcoming_api_error(self, planning_mcp_server):
         """Test get_relevant_upcoming when backend raises an API error."""
         with patch.object(planning_mcp_server.insights_client, "get") as mock_get:
-            mock_get.side_effect = Exception("Backend unavailable")
+            mock_get.side_effect = RuntimeError("Backend unavailable")
 
-            result = await planning_mcp_server.get_relevant_upcoming()
+            with pytest.raises(InsightsApiError) as exc_info:
+                await planning_mcp_server.get_relevant_upcoming()
 
-            # Reuse common helper to validate error formatting
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)

--- a/src/planning_mcp/tests/test_rhel_lifecycle.py
+++ b/src/planning_mcp/tests/test_rhel_lifecycle.py
@@ -5,8 +5,9 @@ from unittest.mock import patch
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
-    assert_api_error_result,
+    assert_api_error_message,
 )
 
 
@@ -101,9 +102,9 @@ class TestPlanningGetRhelLifecycle:
     async def test_get_rhel_lifecycle_api_error(self, planning_mcp_server):
         """Test get_rhel_lifecycle when backend raises an API error."""
         with patch.object(planning_mcp_server.insights_client, "get") as mock_get:
-            mock_get.side_effect = Exception("Backend unavailable")
+            mock_get.side_effect = RuntimeError("Backend unavailable")
 
-            result = await planning_mcp_server.get_rhel_lifecycle()
+            with pytest.raises(InsightsApiError) as exc_info:
+                await planning_mcp_server.get_rhel_lifecycle()
 
-            # Reuse common helper to validate error formatting
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)

--- a/src/planning_mcp/tests/test_upcoming.py
+++ b/src/planning_mcp/tests/test_upcoming.py
@@ -5,8 +5,9 @@ from unittest.mock import patch
 
 import pytest
 
+from insights_mcp.errors import InsightsApiError
 from tests.conftest import (
-    assert_api_error_result,
+    assert_api_error_message,
 )
 
 
@@ -128,9 +129,9 @@ class TestPlanningGetUpcomingChanges:
     async def test_get_upcoming_changes_api_error(self, planning_mcp_server):
         """Test get_upcoming_changes when backend raises an API error."""
         with patch.object(planning_mcp_server.insights_client, "get") as mock_get:
-            mock_get.side_effect = Exception("Backend unavailable")
+            mock_get.side_effect = RuntimeError("Backend unavailable")
 
-            result = await planning_mcp_server.get_upcoming_changes()
+            with pytest.raises(InsightsApiError) as exc_info:
+                await planning_mcp_server.get_upcoming_changes()
 
-            # Reuse common helper to validate error formatting
-            assert_api_error_result(result)
+            assert_api_error_message(exc_info.value)

--- a/src/planning_mcp/tools/appstreams.py
+++ b/src/planning_mcp/tools/appstreams.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
-import json
 from logging import Logger
 from typing import Any
 
 from insights_mcp.client import InsightsClient
-from tools.common import normalise_int as _normalise_int
+from tools.common import (
+    normalise_int as _normalise_int,
+)
+from tools.common import (
+    planning_api_error_message,
+    run_insights_tool_request,
+    run_planning_tool_with_errors,
+)
 
 
 async def get_appstreams_lifecycle(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-branches
@@ -21,11 +27,11 @@ async def get_appstreams_lifecycle(  # pylint: disable=too-many-arguments,too-ma
     logger: Logger | None = None,
 ) -> str:
     """Call Application Streams lifecycle endpoints and return a JSON-encoded response."""
-    try:
+
+    async def _load_appstreams() -> str:
         if mode not in ("raw", "streams"):
             raise ValueError(f"Invalid mode '{mode}'. Expected 'raw' or 'streams'.")
 
-        # Normalise major to an int (or None) – tolerate string input from MCP clients.
         major_int = _normalise_int("major", major)
 
         params: dict[str, Any] = {}
@@ -44,21 +50,16 @@ async def get_appstreams_lifecycle(  # pylint: disable=too-many-arguments,too-ma
                 raise ValueError("Parameter 'major' is required when mode='raw'.")
             endpoint = f"lifecycle/app-streams/{major_int}"
         else:
-            # mode == "streams"
-            # Major is intentionally ignored in streams mode; overview is cross-major.
             endpoint = "lifecycle/app-streams/streams"
 
-        # Call backend
-        response = await insights_client.get(endpoint, params=params or None)
+        return await run_insights_tool_request(
+            insights_client.get(endpoint, params=params or None),
+            error_message=lambda exc: planning_api_error_message("application streams lifecycle", exc),
+            logger=logger,
+        )
 
-        # Pass through JSON strings; otherwise encode dict/list to JSON.
-        if isinstance(response, str):
-            return response
-
-        return json.dumps(response)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        error_detail = f"Error retrieving application streams lifecycle: {exc}"
-        if logger:
-            logger.error(error_detail)
-        # Keep the same error shape convention as upcoming.py
-        return f"Error: API Error - {error_detail}"
+    return await run_planning_tool_with_errors(
+        _load_appstreams,
+        "application streams lifecycle",
+        logger,
+    )

--- a/src/planning_mcp/tools/relevant_appstreams.py
+++ b/src/planning_mcp/tools/relevant_appstreams.py
@@ -1,15 +1,11 @@
 """Helpers for the Planning MCP relevant appstreams lifecycle tool."""
-# pylint: disable=duplicate-code
 
 from __future__ import annotations
 
-import json
 from logging import Logger
-from typing import Any
 
 from insights_mcp.client import InsightsClient
-from tools.common import normalise_bool as _normalise_bool
-from tools.common import normalise_int as _normalise_int
+from tools.common import RelevantLifecycleRequest, fetch_relevant_lifecycle
 
 
 async def get_relevant_appstreams(
@@ -34,36 +30,14 @@ async def get_relevant_appstreams(
     Returns:
         A JSON-encoded string with the response data or an error message.
     """
-    try:
-        major_int = _normalise_int("major", major)
-        minor_int = _normalise_int("minor", minor)
-        include_related_bool = _normalise_bool("include_related", include_related)
-
-        if minor_int is not None and major_int is None:
-            raise ValueError("The 'minor' parameter requires 'major' to be specified")
-
-        params: dict[str, Any] = {}
-        if major_int is not None:
-            params["major"] = major_int
-        if minor_int is not None:
-            params["minor"] = minor_int
-        if include_related_bool is not None:
-            params["related"] = include_related_bool
-
-        response: dict[str, Any] | str = await insights_client.get(
-            "relevant/lifecycle/app-streams",
-            params=params,
-            timeout=30,
-        )
-
-        # The underlying client may already return a JSON string; if so, pass it through.
-        if isinstance(response, str):
-            return response
-
-        # Otherwise, encode the dict to a JSON string for the MCP client.
-        return json.dumps(response)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        error_detail = f"Error retrieving relevant appstreams: {exc}"
-        if logger:
-            logger.error(error_detail)
-        return f"Error: API Error - {error_detail}"
+    return await fetch_relevant_lifecycle(
+        insights_client,
+        RelevantLifecycleRequest(
+            endpoint="relevant/lifecycle/app-streams",
+            operation="relevant appstreams",
+            major=major,
+            minor=minor,
+            include_related=include_related,
+        ),
+        logger,
+    )

--- a/src/planning_mcp/tools/relevant_rhel_lifecycle.py
+++ b/src/planning_mcp/tools/relevant_rhel_lifecycle.py
@@ -1,13 +1,11 @@
 """Helpers for the Planning MCP relevant-rhel-lifecycle tool."""
-# pylint: disable=duplicate-code
 
-import json
+from __future__ import annotations
+
 from logging import Logger
-from typing import Any
 
 from insights_mcp.client import InsightsClient
-from tools.common import normalise_bool as _normalise_bool
-from tools.common import normalise_int as _normalise_int
+from tools.common import RelevantLifecycleRequest, fetch_relevant_lifecycle
 
 
 async def get_relevant_rhel_lifecycle(
@@ -18,36 +16,14 @@ async def get_relevant_rhel_lifecycle(
     include_related: bool | str = False,
 ) -> str:
     """Call GET relevant/lifecycle/rhel and return a JSON-encoded response."""
-    try:
-        major_int = _normalise_int("major", major)
-        minor_int = _normalise_int("minor", minor)
-        include_related_bool = _normalise_bool("include_related", include_related)
-
-        if minor_int is not None and major_int is None:
-            raise ValueError("The 'minor' parameter requires 'major' to be specified")
-
-        params: dict[str, Any] = {}
-        if include_related_bool is not None:
-            params["related"] = include_related_bool
-        if major_int is not None:
-            params["major"] = major_int
-        if minor_int is not None:
-            params["minor"] = minor_int
-
-        response: dict[str, Any] | str = await insights_client.get(
-            "relevant/lifecycle/rhel",
-            params=params or None,
-            timeout=30,
-        )
-
-        # The underlying client may already return a JSON string; if so, pass it through.
-        if isinstance(response, str):
-            return response
-
-        # Otherwise, encode the dict to a JSON string for the MCP client.
-        return json.dumps(response)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        error_detail = f"Error retrieving relevant RHEL lifecycle: {exc}"
-        if logger:
-            logger.error(error_detail)
-        return f"Error: API Error - {error_detail}"
+    return await fetch_relevant_lifecycle(
+        insights_client,
+        RelevantLifecycleRequest(
+            endpoint="relevant/lifecycle/rhel",
+            operation="relevant RHEL lifecycle",
+            major=major,
+            minor=minor,
+            include_related=include_related,
+        ),
+        logger,
+    )

--- a/src/planning_mcp/tools/relevant_upcoming.py
+++ b/src/planning_mcp/tools/relevant_upcoming.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from logging import Logger
-from typing import Any
 
 from insights_mcp.client import InsightsClient
-from tools.common import normalise_int as _normalise_int
+from tools.common import RelevantInventoryFilters, fetch_relevant_inventory_json
 
 
 async def get_relevant_upcoming_changes(
@@ -29,33 +27,10 @@ async def get_relevant_upcoming_changes(
     Returns:
         A JSON-encoded string with the response data or an error message.
     """
-    try:
-        major_int = _normalise_int("major", major)
-        minor_int = _normalise_int("minor", minor)
-
-        if minor_int is not None and major_int is None:
-            raise ValueError("The 'minor' parameter requires 'major' to be specified")
-
-        params: dict[str, Any] = {}
-        if major_int is not None:
-            params["major"] = major_int
-        if minor_int is not None:
-            params["minor"] = minor_int
-
-        response: dict[str, Any] | str = await insights_client.get(
-            "relevant/upcoming-changes",
-            params=params or None,
-            timeout=30,
-        )
-
-        # The underlying client may already return a JSON string; if so, pass it through.
-        if isinstance(response, str):
-            return response
-
-        # Otherwise, encode the dict to a JSON string for the MCP client.
-        return json.dumps(response)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        error_detail = f"Error retrieving relevant upcoming changes: {exc}"
-        if logger:
-            logger.error(error_detail)
-        return f"Error: API Error - {error_detail}"
+    return await fetch_relevant_inventory_json(
+        insights_client,
+        "relevant/upcoming-changes",
+        operation="relevant upcoming changes",
+        logger=logger,
+        filters=RelevantInventoryFilters(major=major, minor=minor),
+    )

--- a/src/planning_mcp/tools/rhel_lifecycle.py
+++ b/src/planning_mcp/tools/rhel_lifecycle.py
@@ -2,26 +2,17 @@
 
 from __future__ import annotations
 
-import json
 from logging import Logger
-from typing import Any
 
 from insights_mcp.client import InsightsClient
+from tools.common import fetch_insights_json
 
 
 async def get_rhel_lifecycle(insights_client: InsightsClient, logger: Logger | None = None) -> str:
     """Call GET /lifecycle/rhel and return a JSON-encoded response."""
-    try:
-        response: dict[str, Any] | str = await insights_client.get("lifecycle/rhel")
-
-        # The underlying client may already return a JSON string; if so, pass it through.
-        if isinstance(response, str):
-            return response
-
-        # Otherwise, encode the dict to a JSON string for the MCP client.
-        return json.dumps(response)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        error_detail = f"Error retrieving RHEL lifecycle data: {exc}"
-        if logger:
-            logger.error(error_detail)
-        return f"Error: API Error - {error_detail}"
+    return await fetch_insights_json(
+        insights_client,
+        "lifecycle/rhel",
+        operation="RHEL lifecycle data",
+        logger=logger,
+    )

--- a/src/planning_mcp/tools/upcoming.py
+++ b/src/planning_mcp/tools/upcoming.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from logging import Logger
-from typing import Any
 
 from insights_mcp.client import InsightsClient
+from tools.common import fetch_insights_json
 
 
 async def get_upcoming_changes(
@@ -14,17 +13,9 @@ async def get_upcoming_changes(
     logger: Logger | None = None,
 ) -> str:
     """Call GET /upcoming-changes and return a JSON-encoded response."""
-    try:
-        response: dict[str, Any] | str = await insights_client.get("upcoming-changes")
-
-        # The underlying client may already return a JSON string; if so, pass it through.
-        if isinstance(response, str):
-            return response
-
-        # Otherwise, encode the dict to a JSON string for the MCP client.
-        return json.dumps(response)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        error_detail = f"Error retrieving upcoming changes: {exc}"
-        if logger:
-            logger.error(error_detail)
-        return f"Error: API Error - {error_detail}"
+    return await fetch_insights_json(
+        insights_client,
+        "upcoming-changes",
+        operation="upcoming changes",
+        logger=logger,
+    )

--- a/src/tools/common.py
+++ b/src/tools/common.py
@@ -1,5 +1,47 @@
 """Shared functions for Insights MCP tools."""
 
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from logging import Logger
+from typing import Any, NoReturn
+
+from insights_mcp.client import InsightsClient
+from insights_mcp.errors import InsightsApiError
+
+# Wrapped when mapping tool input or transport failures to InsightsApiError (not bare Exception).
+TOOL_REQUEST_ERRORS = (ValueError, RuntimeError)
+
+
+@dataclass(frozen=True)
+class InsightsGetRequest:
+    """Optional parameters for an Insights client GET call."""
+
+    params: dict[str, Any] | None = None
+    timeout: int | None = None
+
+
+@dataclass(frozen=True)
+class RelevantInventoryFilters:
+    """Major/minor inventory filters for relevant/* planning endpoints."""
+
+    major: int | str | None = None
+    minor: int | str | None = None
+    extra_params: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class RelevantLifecycleRequest:
+    """Request parameters for relevant lifecycle endpoints with optional ``related`` filter."""
+
+    endpoint: str
+    operation: str
+    major: int | str | None = None
+    minor: int | str | None = None
+    include_related: bool | str = True
+
 
 def normalise_int(name: str, value: int | str | None) -> int | None:
     """Normalise value to an int (or None) - tolerate string input from MCP clients.
@@ -53,3 +95,183 @@ def normalise_bool(name: str, value: bool | str | None) -> bool | None:
 
     # Raise exception in case of any other type provided
     raise ValueError(f"Parameter '{name}' must be a boolean; got '{value}' of type '{type(value).__name__}'.")
+
+
+def encode_insights_json_response(response: dict[str, Any] | str | list[Any]) -> str:
+    """Encode an Insights API response as a JSON string for MCP tool output.
+
+    Args:
+        response: Dict/list from the client, or an already-serialized JSON string.
+
+    Returns:
+        JSON text suitable for returning from an MCP tool.
+    """
+    if isinstance(response, str):
+        return response
+    return json.dumps(response)
+
+
+def raise_insights_tool_error(
+    exc: Exception,
+    message: str,
+    logger: Logger | None = None,
+) -> NoReturn:
+    """Log and re-raise a tool failure as InsightsApiError.
+
+    Args:
+        exc: The original exception to chain.
+        message: Full error message for the MCP client (caller defines wording).
+        logger: Optional logger; when set, logs the message at error level.
+
+    Raises:
+        InsightsApiError: Always raised with ``message`` chained from ``exc``.
+    """
+    if logger:
+        logger.error(message)
+    raise InsightsApiError(message) from exc
+
+
+def planning_api_error_message(operation: str, exc: Exception) -> str:
+    """Build the standard planning toolset API error message."""
+    error_detail = f"Error retrieving {operation}: {exc}"
+    return f"Error: API Error - {error_detail}"
+
+
+def validate_minor_requires_major(minor_int: int | None, major_int: int | None) -> None:
+    """Raise when minor is set without a major version filter."""
+    if minor_int is not None and major_int is None:
+        raise ValueError("The 'minor' parameter requires 'major' to be specified")
+
+
+def build_major_minor_params(
+    major_int: int | None,
+    minor_int: int | None,
+    extra_params: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Build query parameters for relevant/inventory-filtered Insights GET requests."""
+    params: dict[str, Any] = dict(extra_params or {})
+    if major_int is not None:
+        params["major"] = major_int
+    if minor_int is not None:
+        params["minor"] = minor_int
+    return params or None
+
+
+async def run_planning_tool_with_errors(
+    operation: Callable[[], Awaitable[str]],
+    operation_name: str,
+    logger: Logger | None = None,
+) -> str:
+    """Run a planning tool coroutine and map failures to InsightsApiError."""
+    try:
+        return await operation()
+    except TOOL_REQUEST_ERRORS as exc:
+        raise_insights_tool_error(
+            exc,
+            planning_api_error_message(operation_name, exc),
+            logger,
+        )
+
+
+async def run_insights_tool_request(
+    request: Awaitable[dict[str, Any] | str | list[Any]],
+    *,
+    error_message: Callable[[Exception], str],
+    logger: Logger | None = None,
+) -> str:
+    """Await an Insights client call, encode JSON, and map failures to InsightsApiError."""
+    try:
+        response = await request
+        return encode_insights_json_response(response)
+    except TOOL_REQUEST_ERRORS as exc:
+        raise_insights_tool_error(exc, error_message(exc), logger)
+
+
+def build_include_related_params(include_related: bool | str) -> dict[str, Any] | None:
+    """Build optional ``related`` query parameter for relevant lifecycle endpoints."""
+    include_related_bool = normalise_bool("include_related", include_related)
+    extra_params: dict[str, Any] = {}
+    if include_related_bool is not None:
+        extra_params["related"] = include_related_bool
+    return extra_params or None
+
+
+async def fetch_relevant_inventory_json(
+    insights_client: InsightsClient,
+    endpoint: str,
+    *,
+    operation: str,
+    logger: Logger | None = None,
+    filters: RelevantInventoryFilters | None = None,
+) -> str:
+    """GET a relevant/* endpoint with optional major/minor inventory filters."""
+    inventory_filters = filters or RelevantInventoryFilters()
+    major_int = normalise_int("major", inventory_filters.major)
+    minor_int = normalise_int("minor", inventory_filters.minor)
+
+    async def _load_relevant() -> str:
+        validate_minor_requires_major(minor_int, major_int)
+        params = build_major_minor_params(major_int, minor_int, inventory_filters.extra_params)
+        return await run_insights_tool_request(
+            insights_client.get(endpoint, params=params, timeout=30),
+            error_message=lambda exc: planning_api_error_message(operation, exc),
+            logger=logger,
+        )
+
+    return await run_planning_tool_with_errors(_load_relevant, operation, logger)
+
+
+async def fetch_relevant_lifecycle(
+    insights_client: InsightsClient,
+    request: RelevantLifecycleRequest,
+    logger: Logger | None = None,
+) -> str:
+    """GET a relevant lifecycle endpoint that supports the ``related`` filter."""
+    return await fetch_relevant_inventory_json(
+        insights_client,
+        request.endpoint,
+        operation=request.operation,
+        logger=logger,
+        filters=RelevantInventoryFilters(
+            major=request.major,
+            minor=request.minor,
+            extra_params=build_include_related_params(request.include_related),
+        ),
+    )
+
+
+async def fetch_insights_json(
+    insights_client: InsightsClient,
+    endpoint: str,
+    *,
+    operation: str,
+    logger: Logger | None = None,
+    request: InsightsGetRequest | None = None,
+) -> str:
+    """GET an Insights endpoint and return a JSON-encoded MCP tool response.
+
+    Args:
+        insights_client: The Insights API client to use for the request.
+        endpoint: API path relative to the toolset base URL.
+        operation: Human-readable operation name for error messages.
+        logger: Optional logger for error messages.
+        params: Optional query parameters.
+        timeout: Optional request timeout in seconds.
+
+    Returns:
+        JSON-encoded response string.
+
+    Raises:
+        InsightsApiError: On API or unexpected failures.
+    """
+    get_request = request or InsightsGetRequest()
+    request_kwargs: dict[str, Any] = {}
+    if get_request.params is not None:
+        request_kwargs["params"] = get_request.params
+    if get_request.timeout is not None:
+        request_kwargs["timeout"] = get_request.timeout
+    return await run_insights_tool_request(
+        insights_client.get(endpoint, **request_kwargs),
+        error_message=lambda exc: planning_api_error_message(operation, exc),
+        logger=logger,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,8 +232,17 @@ def setup_mcp_mock(
         yield mock_headers
 
 
+def assert_api_error_message(exception: BaseException, error_message: str = "API Error") -> None:
+    """Assert that an InsightsApiError message matches expected API error text."""
+    error_text = str(exception)
+    assert error_text.startswith(f"Error: {error_message}") or error_message.lower() in error_text.lower()
+
+
 def assert_api_error_result(result, error_message="API Error"):
-    """Helper to assert API error results."""
+    """Helper to assert API error results returned as strings (legacy).
+
+    Prefer ``pytest.raises(InsightsApiError)`` with ``assert_api_error_message``.
+    """
     assert result.startswith(f"Error: {error_message}") or error_message.lower() in result.lower()
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 import pytest
 from authlib.integrations.httpx_client import OAuthError
 
-# Clean import - no sys.path.insert needed with proper package structure!
 from image_builder_mcp import ImageBuilderMCP
+from insights_mcp.errors import InsightsApiError
 
 # Brand test cases for HTTP/SSE transports - only need to verify id header
 BRAND_HEADER_TEST_CASES = ["insights-client-id", "lightspeed-client-id"]
@@ -34,7 +34,7 @@ class TestAuthentication:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("function_name,kwargs", AUTH_FUNCTIONS)
     async def test_function_no_auth(self, function_name, kwargs):
-        """Test that functions without authentication return error."""
+        """Test that functions without authentication raise InsightsApiError."""
         mcp_server = ImageBuilderMCP()
         mcp_server.init_insights_client(
             client_id="test-client-id",
@@ -43,32 +43,25 @@ class TestAuthentication:
         )
         mcp_server.register_tools()
 
-        # Mock fetch_token to simulate OAuth error without making real network calls
         async def mock_fetch_token(*args, **kwargs):
             raise OAuthError(error="invalid_client", description="Invalid client or Invalid client credentials")
 
         with patch.object(mcp_server.insights_client.client, "fetch_token", new=mock_fetch_token):
-            # Call the method
             method = getattr(mcp_server, function_name)
-            result = await method(**kwargs)
+            with pytest.raises(InsightsApiError) as exc_info:
+                await method(**kwargs)
 
-            # Should return authentication error
-            # The mocked implementation raises OAuthError which gets caught and formatted
-            assert "Invalid client or Invalid client credentials" in result
-            assert "[INSTRUCTION]" in result
+            error_message = str(exc_info.value)
+            assert "Invalid client or Invalid client credentials" in error_message
+            assert "[INSTRUCTION]" in error_message
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("function_name,kwargs", AUTH_FUNCTIONS)
     @pytest.mark.parametrize("expected_id_env", BRAND_ENV_TEST_CASES, ids=BRAND_ENV_IDS)
     async def test_function_no_auth_error_message(self, function_name, kwargs, expected_id_env, monkeypatch):
-        """Test that functions return the no_auth_error() message when authentication is missing.
-
-        Tests that the correct branded env variable names appear in the error message for stdio transport.
-        """
-        # Patch the brand env variable name in the client module
+        """Test auth error message when credentials are missing (stdio transport)."""
         monkeypatch.setattr("insights_mcp.client.BRAND_CLIENT_ID_ENV", expected_id_env)
 
-        # Create MCP server without default credentials (default is stdio transport)
         mcp_server = ImageBuilderMCP()
         mcp_server.init_insights_client(
             client_id=None,
@@ -78,12 +71,13 @@ class TestAuthentication:
         mcp_server.register_tools()
 
         method = getattr(mcp_server, function_name)
-        result = await method(**kwargs)
+        with pytest.raises(InsightsApiError) as exc_info:
+            await method(**kwargs)
 
-        # Verify branded env variable name appears in error message
-        assert "[INSTRUCTION] There seems to be a problem with the request." in result
-        assert "authentication problem" in result
-        assert expected_id_env in result
+        error_message = str(exc_info.value)
+        assert "[INSTRUCTION] There seems to be a problem with the request." in error_message
+        assert "authentication problem" in error_message
+        assert expected_id_env in error_message
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("function_name,kwargs", AUTH_FUNCTIONS)
@@ -91,14 +85,9 @@ class TestAuthentication:
     async def test_function_no_auth_error_message_sse_transport(
         self, function_name, kwargs, expected_id_header, monkeypatch
     ):
-        """Test that functions return the no_auth_error() message for SSE transport.
-
-        Tests that the correct branded header name appears in the error message.
-        """
-        # Patch the brand header value in the client module
+        """Test auth error message for SSE transport."""
         monkeypatch.setattr("insights_mcp.client.BRAND_CLIENT_ID_HEADER", expected_id_header)
 
-        # Create MCP server with SSE transport
         mcp_server = ImageBuilderMCP()
         mcp_server.init_insights_client(
             client_id=None,
@@ -109,12 +98,13 @@ class TestAuthentication:
         mcp_server.register_tools()
 
         method = getattr(mcp_server, function_name)
-        result = await method(**kwargs)
+        with pytest.raises(InsightsApiError) as exc_info:
+            await method(**kwargs)
 
-        # Verify branded header appears in error message
-        assert "[INSTRUCTION] There seems to be a problem with the request." in result
-        assert "authentication problem" in result
-        assert expected_id_header in result
+        error_message = str(exc_info.value)
+        assert "[INSTRUCTION] There seems to be a problem with the request." in error_message
+        assert "authentication problem" in error_message
+        assert expected_id_header in error_message
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("function_name,kwargs", AUTH_FUNCTIONS)
@@ -122,14 +112,9 @@ class TestAuthentication:
     async def test_function_no_auth_error_message_http_transport(
         self, function_name, kwargs, expected_id_header, monkeypatch
     ):
-        """Test that functions return the no_auth_error() message for HTTP transport.
-
-        Tests that the correct branded header name appears in the error message.
-        """
-        # Patch the brand header value in the client module
+        """Test auth error message for HTTP transport."""
         monkeypatch.setattr("insights_mcp.client.BRAND_CLIENT_ID_HEADER", expected_id_header)
 
-        # Create MCP server with HTTP transport
         mcp_server = ImageBuilderMCP()
         mcp_server.init_insights_client(
             client_id=None,
@@ -140,9 +125,10 @@ class TestAuthentication:
         mcp_server.register_tools()
 
         method = getattr(mcp_server, function_name)
-        result = await method(**kwargs)
+        with pytest.raises(InsightsApiError) as exc_info:
+            await method(**kwargs)
 
-        # Verify branded header appears in error message
-        assert "[INSTRUCTION] There seems to be a problem with the request." in result
-        assert "authentication problem" in result
-        assert expected_id_header in result
+        error_message = str(exc_info.value)
+        assert "[INSTRUCTION] There seems to be a problem with the request." in error_message
+        assert "authentication problem" in error_message
+        assert expected_id_header in error_message

--- a/tests/test_oauth_client.py
+++ b/tests/test_oauth_client.py
@@ -8,6 +8,7 @@ token extraction from FastMCP context and OAuth-authenticated API calls.
 # Pytest fixtures are injected as function parameters, which pylint
 # incorrectly flags as redefining names from outer scope.
 
+import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -127,10 +128,12 @@ class TestMakeRequest:
 
     @pytest.fixture
     def mock_get_response(self):
-        """Mock HTTP GET response."""
+        """Mock HTTP GET response compatible with InsightsClientBase.make_request."""
         response = Mock()
         response.status_code = 200
-        response.json.return_value = {"data": "test"}
+        response.headers = {}
+        response.content = json.dumps({"data": "test"}).encode("utf-8")
+        response.raise_for_status = Mock()
         return response
 
     @pytest.mark.asyncio

--- a/tests/test_tool_is_error.py
+++ b/tests/test_tool_is_error.py
@@ -1,0 +1,60 @@
+"""Regression tests for HMS-10703: MCP CallToolResult isError on tool failures."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp import Client
+
+from insights_mcp.errors import InsightsApiError
+from vulnerability_mcp.server import mcp as VulnerabilityMCP
+
+HTTP_404_MESSAGE = (
+    'Unexpected HTTP status code: 404, content: {"errors": [{"detail": "No such CVE ID", "status": "404"}]}'
+)
+AUTH_ERROR_MESSAGE = (
+    "[INSTRUCTION] There seems to be a problem with the request. "
+    "Without asking the user, immediately call get_insights_mcp_version() to check "
+    "if we are on the latest release."
+)
+
+
+@pytest.fixture(name="vuln_mcp")
+def vulnerability_mcp_initialized():
+    """Initialize vulnerability MCP with dummy credentials for tool calls."""
+    VulnerabilityMCP.init_insights_client(
+        client_id="test-client-id",
+        client_secret="test-client-secret",
+        oauth_enabled=False,
+    )
+    return VulnerabilityMCP
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("side_effect", "expected_substring", "cve"),
+    [
+        (InsightsApiError(HTTP_404_MESSAGE), "404", "CVE-9999-9999"),
+        (
+            InsightsApiError(AUTH_ERROR_MESSAGE),
+            "[INSTRUCTION] There seems to be a problem with the request.",
+            "CVE-2024-1234",
+        ),
+    ],
+)
+async def test_tool_call_sets_is_error(vuln_mcp, side_effect, expected_substring, cve):
+    """API and auth failures must surface as CallToolResult with isError=true."""
+    async with Client(vuln_mcp) as client:
+        with patch.object(
+            vuln_mcp.insights_client,
+            "get",
+            new_callable=AsyncMock,
+            side_effect=side_effect,
+        ):
+            result = await client.call_tool(
+                "get_cve",
+                {"cve": cve},
+                raise_on_error=False,
+            )
+
+    assert result.is_error is True
+    assert expected_substring in result.content[0].text


### PR DESCRIPTION
Introduces `isError: true` of MCP specification for errors