### PR TITLE
Add compass catalog info (RHIN-2604)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,15 @@ jobs:
       - name: Run lint
         run: make lint
 
+      - name: Check generated docs are up to date
+        run: |
+          make generate-docs
+          if git diff --name-only | grep .; then
+            echo "Error: generated files are out of date"
+            echo "Please run 'make generate-docs' and commit the changes"
+            exit 1
+          fi
+
       - name: Fail if there are changed files
         run: |
           if git diff --name-only | grep .; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,3 +66,11 @@ repos:
           - llama-index-core
           - llama-index-tools-mcp
           - llama-index-llms-openai
+  - repo: local
+    hooks:
+      - id: check-generated-docs
+        name: Check generated docs (usage, toolsets, catalog-info)
+        entry: bash -c 'make generate-docs && git diff --exit-code usage.md toolsets.md catalog-info.yaml'
+        language: system
+        pass_filenames: false
+        stages: [manual]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,13 @@ The project uses a **toolset-based architecture** where each service is implemen
 - Most toolsets: `src/<toolset_name>_mcp/server.py` (e.g., `src/vulnerability_mcp/server.py`)
 - Legacy pattern: `src/insights_mcp/servers/<name>.py` (e.g., example toolset)
 
-**Example toolsets (see `src/insights_mcp/server.py` MCPS list for complete current list):**
+**Example toolsets (see `src/insights_mcp/toolsets.py` MCPS list for complete current list):**
 - **image-builder** (`src/image_builder_mcp/server.py`): Linux image building tools
 - **vulnerability** (`src/vulnerability_mcp/server.py`): Security vulnerability management
 - **inventory** (`src/inventory_mcp/server.py`): System inventory management
 
 **Toolset Registration:**
-- Toolsets are registered in `MCPS` list in `src/insights_mcp/server.py`
+- Toolsets are registered in `MCPS` list in `src/insights_mcp/toolsets.py`
 - Each toolset has a unique `toolset_name` for identification
 - Tools are mounted with toolset prefix (e.g., `image-builder_get_blueprints`)
 - Users can select specific toolsets: `insights-mcp --toolset=image-builder`
@@ -226,7 +226,7 @@ insights-mcp --toolset=image-builder,vulnerability # Multiple specific toolsets
 1. Create new class inheriting from `InsightsMCP` in `src/insights_mcp/servers/`
 2. Set unique `toolset_name` and appropriate `api_path`
 3. Implement tools using `@mcp.tool()` decorator
-4. Add toolset to `MCPS` list in `src/insights_mcp/server.py`
+4. Add toolset to `MCPS` list in `src/insights_mcp/toolsets.py`
 5. Write unit and integration tests
 
 ### Adding New Tools to Existing Toolsets

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,13 @@ run-oauth: build ## Run the MCP server with OAuth transport
 ALL_PYTHON_FILES := $(shell find src -name "*.py")
 
 .PHONY: generate-docs
-generate-docs: usage.md toolsets.md docs/architecture-structure.svg docs/architecture-deployment.svg ## Generate documentation from the MCP server
+generate-docs: usage.md toolsets.md catalog-info.yaml docs/architecture-structure.svg docs/architecture-deployment.svg ## Generate documentation from the MCP server
+
+catalog-info.yaml: catalog-info.base.yaml $(ALL_PYTHON_FILES) Makefile
+	uv run python scripts/generate_catalog_info.py
+
+.PHONY: catalog-info
+catalog-info: catalog-info.yaml ## Regenerate catalog-info.yaml tool primitives
 
 usage.md: $(ALL_PYTHON_FILES) Makefile
 	uv tool install -e .

--- a/catalog-info.base.yaml
+++ b/catalog-info.base.yaml
@@ -7,15 +7,38 @@ metadata:
 
   description: An MCP server to enable AI agents to query platform data, analyze systems, identify critical vulnerabilities, and perform proactive planning and lifecycle management.
 
+  annotations:
+    github.com/project-slug: RedHatInsights/insights-mcp
+    backstage.io/source-location: url:https://github.com/RedHatInsights/insights-mcp/tree/main/
+    backstage.io/managed-by-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/managed-by-origin-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/view-url: https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RedHatInsights/insights-mcp/edit/main/catalog-info.yaml
+    backstage.io/techdocs-ref: dir:.
+    feedback/type: JIRA
+    jira/project-key: HMS
+    feedback/host: https://redhat.atlassian.net
+    feedback/email-to: rh-lightspeed-mcp@redhat.com
+
   tags:
     - mcp
     - lightspeed
     - administration
 
   links:
+    - url: https://github.com/RedHatInsights/insights-mcp/blob/main/README.md
+      title: README
+      type: documentation
+    - url: https://github.com/RedHatInsights/insights-mcp/issues
+      title: Report an issue
+      type: issue-tracker
     - url: https://catalog.redhat.com/en/software/container-stacks/detail/69441d9d0df8059c340fa3f1
       title: View on Red Hat Catalog
       type: documentation
+
+relations:
+  - type: ownedBy
+    targetRef: group:redhat/rh-lightspeed-mcp
 
 spec:
   type: local

--- a/catalog-info.base.yaml
+++ b/catalog-info.base.yaml
@@ -1,0 +1,40 @@
+apiVersion: mcp/v1beta1
+kind: MCPServer
+metadata:
+  annotations:
+    github.com/project-slug: RedHatInsights/insights-mcp
+    backstage.io/managed-by-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/managed-by-origin-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/view-url: https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RedHatInsights/insights-mcp/edit/main/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RedHatInsights/insights-mcp/tree/main/
+  name: lightspeed-mcp-server
+  title: Red Hat Lightspeed MCP Server
+  namespace: redhat
+  description: An MCP server to enable AI agents to query platform data, analyze
+    systems, identify critical vulnerabilities, and perform proactive planning
+    and lifecycle management.
+  tags:
+    - mcp
+    - lightspeed
+    - administration
+    - placeholder
+  links:
+    - url: https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+      title: catalog-info.yaml on GitHub
+      type: documentation
+    - url: https://catalog.redhat.com/en/software/container-stacks/detail/69441d9d0df8059c340fa3f1
+      title: View on Red Hat Catalog
+      type: documentation
+relations:
+  - type: ownedBy
+    targetRef: group:redhat/rh-lightspeed-mcp
+spec:
+  type: local
+  lifecycle: developer-preview
+  owner: group:redhat/rh-lightspeed-mcp
+  packages:
+    - type: docker
+      registry: ghcr.io
+      name: redhatinsights/red-hat-lightspeed-mcp
+      version: latest

--- a/catalog-info.base.yaml
+++ b/catalog-info.base.yaml
@@ -1,40 +1,33 @@
 apiVersion: mcp/v1beta1
 kind: MCPServer
 metadata:
-  annotations:
-    github.com/project-slug: RedHatInsights/insights-mcp
-    backstage.io/managed-by-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
-    backstage.io/managed-by-origin-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
-    backstage.io/view-url: https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/RedHatInsights/insights-mcp/edit/main/catalog-info.yaml
-    backstage.io/source-location: url:https://github.com/RedHatInsights/insights-mcp/tree/main/
   name: lightspeed-mcp-server
   title: Red Hat Lightspeed MCP Server
   namespace: redhat
-  description: An MCP server to enable AI agents to query platform data, analyze
-    systems, identify critical vulnerabilities, and perform proactive planning
-    and lifecycle management.
+
+  description: An MCP server to enable AI agents to query platform data, analyze systems, identify critical vulnerabilities, and perform proactive planning and lifecycle management.
+
   tags:
     - mcp
     - lightspeed
     - administration
-    - placeholder
+
   links:
-    - url: https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
-      title: catalog-info.yaml on GitHub
-      type: documentation
     - url: https://catalog.redhat.com/en/software/container-stacks/detail/69441d9d0df8059c340fa3f1
       title: View on Red Hat Catalog
       type: documentation
-relations:
-  - type: ownedBy
-    targetRef: group:redhat/rh-lightspeed-mcp
+
 spec:
   type: local
   lifecycle: developer-preview
   owner: group:redhat/rh-lightspeed-mcp
+
   packages:
-    - type: docker
+    - type: container
+      registry: quay.io
+      name: redhat-services-prod/insights-management-tenant/insights-mcp/red-hat-lightspeed-mcp
+      version: latest
+    - type: container
       registry: ghcr.io
       name: redhatinsights/red-hat-lightspeed-mcp
       version: latest

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,15 +7,38 @@ metadata:
 
   description: An MCP server to enable AI agents to query platform data, analyze systems, identify critical vulnerabilities, and perform proactive planning and lifecycle management.
 
+  annotations:
+    github.com/project-slug: RedHatInsights/insights-mcp
+    backstage.io/source-location: url:https://github.com/RedHatInsights/insights-mcp/tree/main/
+    backstage.io/managed-by-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/managed-by-origin-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/view-url: https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RedHatInsights/insights-mcp/edit/main/catalog-info.yaml
+    backstage.io/techdocs-ref: dir:.
+    feedback/type: JIRA
+    jira/project-key: HMS
+    feedback/host: https://redhat.atlassian.net
+    feedback/email-to: rh-lightspeed-mcp@redhat.com
+
   tags:
     - mcp
     - lightspeed
     - administration
 
   links:
+    - url: https://github.com/RedHatInsights/insights-mcp/blob/main/README.md
+      title: README
+      type: documentation
+    - url: https://github.com/RedHatInsights/insights-mcp/issues
+      title: Report an issue
+      type: issue-tracker
     - url: https://catalog.redhat.com/en/software/container-stacks/detail/69441d9d0df8059c340fa3f1
       title: View on Red Hat Catalog
       type: documentation
+
+relations:
+  - type: ownedBy
+    targetRef: group:redhat/rh-lightspeed-mcp
 
 spec:
   type: local

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,44 +1,38 @@
 apiVersion: mcp/v1beta1
 kind: MCPServer
 metadata:
-  annotations:
-    github.com/project-slug: RedHatInsights/insights-mcp
-    backstage.io/managed-by-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
-    backstage.io/managed-by-origin-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
-    backstage.io/view-url: https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/RedHatInsights/insights-mcp/edit/main/catalog-info.yaml
-    backstage.io/source-location: url:https://github.com/RedHatInsights/insights-mcp/tree/main/
   name: lightspeed-mcp-server
   title: Red Hat Lightspeed MCP Server
   namespace: redhat
-  description: An MCP server to enable AI agents to query platform data, analyze
-    systems, identify critical vulnerabilities, and perform proactive planning
-    and lifecycle management.
+
+  description: An MCP server to enable AI agents to query platform data, analyze systems, identify critical vulnerabilities, and perform proactive planning and lifecycle management.
+
   tags:
     - mcp
     - lightspeed
     - administration
-    - placeholder
+
   links:
-    - url: https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
-      title: catalog-info.yaml on GitHub
-      type: documentation
     - url: https://catalog.redhat.com/en/software/container-stacks/detail/69441d9d0df8059c340fa3f1
       title: View on Red Hat Catalog
       type: documentation
-relations:
-  - type: ownedBy
-    targetRef: group:redhat/rh-lightspeed-mcp
+
 spec:
   type: local
   lifecycle: developer-preview
   owner: group:redhat/rh-lightspeed-mcp
+
   packages:
-    - type: docker
+    - type: container
+      registry: quay.io
+      name: redhat-services-prod/insights-management-tenant/insights-mcp/red-hat-lightspeed-mcp
+      version: latest
+    - type: container
       registry: ghcr.io
       name: redhatinsights/red-hat-lightspeed-mcp
       version: latest
   primitives:
+    # advisor
     - type: tool
       name: advisor__get_active_rules
       description: "Get Active Advisor Recommendations for Account"
@@ -60,9 +54,11 @@ spec:
     - type: tool
       name: advisor__get_rule_from_node_id
       description: "Find Advisor Recommendations using Knowledge Base solution ID or article ID"
+    # content-sources
     - type: tool
       name: content-sources__list_repositories
       description: "List repositories with filtering and pagination options."
+    # image-builder
     - type: tool
       name: image-builder__blueprint_compose
       description: "Compose an image from a blueprint UUID created with create_blueprint, get_blueprints."
@@ -93,6 +89,7 @@ spec:
     - type: tool
       name: image-builder__update_blueprint
       description: "Update a blueprint."
+    # inventory
     - type: tool
       name: inventory__find_host_by_name
       description: "Find a host by its hostname/display name."
@@ -108,6 +105,7 @@ spec:
     - type: tool
       name: inventory__list_hosts
       description: "List hosts with filtering and sorting options."
+    # planning
     - type: tool
       name: planning__get_appstreams_lifecycle
       description: "Get Application Streams lifecycle information."
@@ -126,18 +124,22 @@ spec:
     - type: tool
       name: planning__get_upcoming_changes
       description: "List upcoming package changes, deprecations, additions and enhancements."
+    # rbac
     - type: tool
       name: rbac__get_all_access
       description: "Get access information for all Red Hat insights applications."
+    # remediations
     - type: tool
       name: remediations__create_vuln_playbook
       description: "Create remediation playbook for given CVEs on given systems to mitigate vulnerabilities."
+    # rhsm
     - type: tool
       name: rhsm__get_activation_key
       description: "Get a specific activation key by name."
     - type: tool
       name: rhsm__get_activation_keys
       description: "Get the list of activation keys available to the authenticated user."
+    # vulnerability
     - type: tool
       name: vulnerability__explain_cves
       description: "Explain why CVEs are affecting my environment."

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,161 @@
+apiVersion: mcp/v1beta1
+kind: MCPServer
+metadata:
+  annotations:
+    github.com/project-slug: RedHatInsights/insights-mcp
+    backstage.io/managed-by-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/managed-by-origin-location: url:https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/view-url: https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RedHatInsights/insights-mcp/edit/main/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RedHatInsights/insights-mcp/tree/main/
+  name: lightspeed-mcp-server
+  title: Red Hat Lightspeed MCP Server
+  namespace: redhat
+  description: An MCP server to enable AI agents to query platform data, analyze
+    systems, identify critical vulnerabilities, and perform proactive planning
+    and lifecycle management.
+  tags:
+    - mcp
+    - lightspeed
+    - administration
+    - placeholder
+  links:
+    - url: https://github.com/RedHatInsights/insights-mcp/blob/main/catalog-info.yaml
+      title: catalog-info.yaml on GitHub
+      type: documentation
+    - url: https://catalog.redhat.com/en/software/container-stacks/detail/69441d9d0df8059c340fa3f1
+      title: View on Red Hat Catalog
+      type: documentation
+relations:
+  - type: ownedBy
+    targetRef: group:redhat/rh-lightspeed-mcp
+spec:
+  type: local
+  lifecycle: developer-preview
+  owner: group:redhat/rh-lightspeed-mcp
+  packages:
+    - type: docker
+      registry: ghcr.io
+      name: redhatinsights/red-hat-lightspeed-mcp
+      version: latest
+  primitives:
+    - type: tool
+      name: advisor__get_active_rules
+      description: "Get Active Advisor Recommendations for Account"
+    - type: tool
+      name: advisor__get_hosts_details_for_rule
+      description: "Get Detailed System Information for Advisor Recommendation"
+    - type: tool
+      name: advisor__get_hosts_hitting_a_rule
+      description: "Get Systems Affected by Advisor Recommendation"
+    - type: tool
+      name: advisor__get_recommendations_stats
+      description: "Get Statistics of Recommendations Across Categories and Risks"
+    - type: tool
+      name: advisor__get_rule_by_text_search
+      description: "Find Advisor Recommendations by Text Search"
+    - type: tool
+      name: advisor__get_rule_details
+      description: "Get Detailed Advisor Recommendation Information"
+    - type: tool
+      name: advisor__get_rule_from_node_id
+      description: "Find Advisor Recommendations using Knowledge Base solution ID or article ID"
+    - type: tool
+      name: content-sources__list_repositories
+      description: "List repositories with filtering and pagination options."
+    - type: tool
+      name: image-builder__blueprint_compose
+      description: "Compose an image from a blueprint UUID created with create_blueprint, get_blueprints."
+    - type: tool
+      name: image-builder__create_blueprint
+      description: "Create a custom Linux image blueprint."
+    - type: tool
+      name: image-builder__get_blueprint_details
+      description: "Get blueprint details."
+    - type: tool
+      name: image-builder__get_blueprints
+      description: "Show user's image blueprints (saved image templates/configurations for"
+    - type: tool
+      name: image-builder__get_compose_details
+      description: "Get detailed information about a specific image build."
+    - type: tool
+      name: image-builder__get_composes
+      description: "Get a list of all image builds (composes) with their UUIDs and basic status."
+    - type: tool
+      name: image-builder__get_distributions
+      description: "Get the list of distributions available to build images with."
+    - type: tool
+      name: image-builder__get_openapi
+      description: "Get OpenAPI spec. Use this to get details e.g for a new blueprint"
+    - type: tool
+      name: image-builder__get_org_id
+      description: "Get the organization ID for RHEL image registration/subscription."
+    - type: tool
+      name: image-builder__update_blueprint
+      description: "Update a blueprint."
+    - type: tool
+      name: inventory__find_host_by_name
+      description: "Find a host by its hostname/display name."
+    - type: tool
+      name: inventory__get_host_details
+      description: "Get detailed information for specific hosts by their IDs."
+    - type: tool
+      name: inventory__get_host_system_profile
+      description: "Get detailed system profile information for specific hosts."
+    - type: tool
+      name: inventory__get_host_tags
+      description: "Get tags for specific hosts."
+    - type: tool
+      name: inventory__list_hosts
+      description: "List hosts with filtering and sorting options."
+    - type: tool
+      name: planning__get_appstreams_lifecycle
+      description: "Get Application Streams lifecycle information."
+    - type: tool
+      name: planning__get_relevant_appstreams
+      description: "Get Application Streams relevant to the requester's inventory (includes lifecycle/support dates)."
+    - type: tool
+      name: planning__get_relevant_rhel_lifecycle
+      description: "Returns RHEL lifecycle information for systems in the requester's inventory."
+    - type: tool
+      name: planning__get_relevant_upcoming
+      description: "List relevant upcoming package changes, deprecations, additions and enhancements to user's systems."
+    - type: tool
+      name: planning__get_rhel_lifecycle
+      description: "Returns life cycle dates for all RHEL majors and minors."
+    - type: tool
+      name: planning__get_upcoming_changes
+      description: "List upcoming package changes, deprecations, additions and enhancements."
+    - type: tool
+      name: rbac__get_all_access
+      description: "Get access information for all Red Hat insights applications."
+    - type: tool
+      name: remediations__create_vuln_playbook
+      description: "Create remediation playbook for given CVEs on given systems to mitigate vulnerabilities."
+    - type: tool
+      name: rhsm__get_activation_key
+      description: "Get a specific activation key by name."
+    - type: tool
+      name: rhsm__get_activation_keys
+      description: "Get the list of activation keys available to the authenticated user."
+    - type: tool
+      name: vulnerability__explain_cves
+      description: "Explain why CVEs are affecting my environment."
+    - type: tool
+      name: vulnerability__get_cve
+      description: "Get details about specific CVE."
+    - type: tool
+      name: vulnerability__get_cve_systems
+      description: "Get list of systems affected by a given CVE."
+    - type: tool
+      name: vulnerability__get_cves
+      description: "Get list of CVEs affecting the account."
+    - type: tool
+      name: vulnerability__get_openapi
+      description: "Get Red Hat Lightspeed Vulnerability OpenAPI specification in JSON format."
+    - type: tool
+      name: vulnerability__get_system_cves
+      description: "Get list of CVEs affecting a given system."
+    - type: tool
+      name: vulnerability__get_systems
+      description: "Get list of systems in Red Hat Lightspeed Vulnerability inventory."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: Red Hat Lightspeed MCP Server
+docs_dir: .
+nav:
+  - Home: README.md
+  - Usage: usage.md
+  - Hacking: HACKING.md
+  - Toolsets: toolsets.md
+plugins:
+  - techdocs-core

--- a/scripts/generate_catalog_info.py
+++ b/scripts/generate_catalog_info.py
@@ -69,10 +69,28 @@ def load_base_catalog(base_path: Path) -> str:
     return base_text
 
 
+def _toolset_from_primitive_name(name: str) -> str:
+    """Extract the toolset prefix from a prefixed primitive name."""
+    toolset, separator, _ = name.partition("__")
+    if not separator:
+        raise ValueError(f"Primitive name must contain '__': got {name!r}")
+    return toolset
+
+
 def format_primitives_yaml(primitives: list[dict[str, str]]) -> str:
-    """Render spec.primitives as YAML with yamllint-compatible indentation."""
+    """Render spec.primitives as YAML with yamllint-compatible indentation.
+
+    Inserts a ``# {toolset}`` comment heading before the first tool of each toolset
+    group. Primitives are expected to be sorted by name so toolsets appear
+    alphabetically.
+    """
     lines = ["  primitives:"]
+    current_toolset: str | None = None
     for primitive in primitives:
+        toolset = _toolset_from_primitive_name(primitive["name"])
+        if toolset != current_toolset:
+            lines.append(f"    # {toolset}")
+            current_toolset = toolset
         lines.append("    - type: tool")
         lines.append(f"      name: {_yaml_scalar(primitive['name'])}")
         lines.append(f"      description: {_yaml_scalar(primitive['description'])}")

--- a/scripts/generate_catalog_info.py
+++ b/scripts/generate_catalog_info.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Generate catalog-info.yaml by merging static base metadata with live tool primitives."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from insights_mcp.catalog_tools import collect_tool_primitives
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BASE_PATH = REPO_ROOT / "catalog-info.base.yaml"
+DEFAULT_OUTPUT_PATH = REPO_ROOT / "catalog-info.yaml"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Merge catalog-info.base.yaml with generated spec.primitives from MCP toolsets.",
+    )
+    parser.add_argument(
+        "--base",
+        type=Path,
+        default=DEFAULT_BASE_PATH,
+        help="Static catalog metadata YAML (default: catalog-info.base.yaml)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="Output catalog-info.yaml path (default: catalog-info.yaml)",
+    )
+    parser.add_argument(
+        "--brand-long",
+        default="Red Hat Lightspeed",
+        help="Value for $container_brand_long in tool descriptions",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if output would differ from the file on disk",
+    )
+    return parser.parse_args()
+
+
+def load_base_catalog(base_path: Path) -> str:
+    """Load the static catalog-info base YAML text.
+
+    Args:
+        base_path: Path to catalog-info.base.yaml.
+
+    Returns:
+        Base file contents with trailing whitespace removed.
+
+    Raises:
+        SystemExit: If the base file is missing.
+    """
+    if not base_path.is_file():
+        raise SystemExit(f"Base catalog file not found: {base_path}")
+
+    base_text = base_path.read_text(encoding="utf-8").rstrip()
+    if not base_text:
+        raise SystemExit(f"Base catalog file is empty: {base_path}")
+
+    return base_text
+
+
+def format_primitives_yaml(primitives: list[dict[str, str]]) -> str:
+    """Render spec.primitives as YAML with yamllint-compatible indentation."""
+    lines = ["  primitives:"]
+    for primitive in primitives:
+        lines.append("    - type: tool")
+        lines.append(f"      name: {_yaml_scalar(primitive['name'])}")
+        lines.append(f"      description: {_yaml_scalar(primitive['description'])}")
+    return "\n".join(lines)
+
+
+def _yaml_scalar(value: str) -> str:
+    """Return a YAML scalar, quoting when required."""
+    if not value:
+        return '""'
+    if _needs_yaml_quotes(value):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return value
+
+
+def _needs_yaml_quotes(value: str) -> bool:
+    """Return True when a plain scalar would be ambiguous in YAML."""
+    if value[0] in "'\"@`:{}[],&*#?|-<>=!%":
+        return True
+    if ":" in value or "#" in value:
+        return True
+    if value.lower() in {"true", "false", "null", "yes", "no", "on", "off"}:
+        return True
+    return any(character.isspace() for character in value)
+
+
+def build_catalog_yaml(base_text: str, *, brand_long: str) -> str:
+    """Merge base catalog text with generated tool primitives.
+
+    Args:
+        base_text: Static catalog YAML without a primitives section.
+        brand_long: Brand name for description template substitution.
+
+    Returns:
+        Complete catalog-info.yaml contents.
+    """
+    primitives = collect_tool_primitives(brand_long=brand_long)
+    return f"{base_text}\n{format_primitives_yaml(primitives)}\n"
+
+
+def validate_catalog_yaml(catalog_yaml: str) -> dict[str, Any]:
+    """Parse generated catalog YAML to catch syntax errors early."""
+    document = yaml.safe_load(catalog_yaml)
+    if not isinstance(document, dict):
+        raise ValueError("Generated catalog-info.yaml must contain a mapping")
+    return document
+
+
+def main() -> None:
+    """Generate or verify catalog-info.yaml."""
+    args = _parse_args()
+    base_path = args.base.resolve()
+    output_path = args.output.resolve()
+
+    base_text = load_base_catalog(base_path)
+    rendered = build_catalog_yaml(base_text, brand_long=args.brand_long)
+    validate_catalog_yaml(rendered)
+
+    if args.check:
+        if not output_path.is_file():
+            print(f"catalog-info.yaml not found: {output_path}", file=sys.stderr)
+            raise SystemExit(1)
+        existing = output_path.read_text(encoding="utf-8")
+        if existing != rendered:
+            diff = difflib.unified_diff(
+                existing.splitlines(keepends=True),
+                rendered.splitlines(keepends=True),
+                fromfile=str(output_path),
+                tofile=f"{output_path} (generated)",
+            )
+            sys.stdout.writelines(diff)
+            print(
+                "catalog-info.yaml is out of date; run: make catalog-info.yaml",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        return
+
+    output_path.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {output_path.relative_to(REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/insights_mcp/catalog_tools.py
+++ b/src/insights_mcp/catalog_tools.py
@@ -4,35 +4,16 @@ from __future__ import annotations
 
 import asyncio
 from string import Template
-from typing import Protocol
+
+from fastmcp.tools import Tool
 
 from insights_mcp.mcp import InsightsMCP
-
-# Deferred import avoids circular dependency: server.py imports this module.
-_MCPS: list[InsightsMCP] | None = None
+from insights_mcp.toolsets import MCPS
 
 _DESCRIPTION_MAX_LENGTH = 100
 
 
-class ToolDescriptionSource(Protocol):
-    """Minimal tool surface used for catalog description extraction."""
-
-    name: str
-    title: str | None
-    description: str | None
-
-
-def _get_mcps() -> list[InsightsMCP]:
-    """Return registered MCP toolsets, importing lazily from server."""
-    global _MCPS  # pylint: disable=global-statement
-    if _MCPS is None:
-        from insights_mcp.server import MCPS  # pylint: disable=import-outside-toplevel
-
-        _MCPS = MCPS
-    return _MCPS
-
-
-def catalog_tool_description(tool: ToolDescriptionSource, *, brand_long: str | None = None) -> str:
+def catalog_tool_description(tool: Tool, *, brand_long: str | None = None) -> str:
     """Extract a short catalog description from an MCP tool.
 
     Uses ``tool.title`` when set by the toolset, otherwise the first line of
@@ -62,10 +43,10 @@ def _truncate_description(first_line: str) -> str:
     return first_line[:truncate_at] + "…"
 
 
-def _list_mounted_tools() -> list[ToolDescriptionSource]:
+def _list_mounted_tools() -> list[Tool]:
     """Register, mount, and list tools using the same naming as InsightsMCPServer."""
     temp_root = InsightsMCP(name="temp", toolset_name="temp", api_path="")
-    for mcp in _get_mcps():
+    for mcp in MCPS:
         try:
             temp_sub = type(mcp)()  # type: ignore[call-arg]
             temp_sub.register_tools()

--- a/src/insights_mcp/catalog_tools.py
+++ b/src/insights_mcp/catalog_tools.py
@@ -1,0 +1,99 @@
+"""Collect MCP tool metadata for Compass catalog-info.yaml generation."""
+
+from __future__ import annotations
+
+import asyncio
+from string import Template
+from typing import Protocol
+
+from insights_mcp.mcp import InsightsMCP
+
+# Deferred import avoids circular dependency: server.py imports this module.
+_MCPS: list[InsightsMCP] | None = None
+
+_DESCRIPTION_MAX_LENGTH = 100
+
+
+class ToolDescriptionSource(Protocol):
+    """Minimal tool surface used for catalog description extraction."""
+
+    name: str
+    title: str | None
+    description: str | None
+
+
+def _get_mcps() -> list[InsightsMCP]:
+    """Return registered MCP toolsets, importing lazily from server."""
+    global _MCPS  # pylint: disable=global-statement
+    if _MCPS is None:
+        from insights_mcp.server import MCPS  # pylint: disable=import-outside-toplevel
+
+        _MCPS = MCPS
+    return _MCPS
+
+
+def catalog_tool_description(tool: ToolDescriptionSource, *, brand_long: str | None = None) -> str:
+    """Extract a short catalog description from an MCP tool.
+
+    Uses ``tool.title`` when set by the toolset, otherwise the first line of
+    ``tool.description``. When ``brand_long`` is provided, ``$container_brand_long``
+    placeholders are substituted.
+
+    Args:
+        tool: MCP tool with title and/or description from toolset registration.
+        brand_long: Optional long brand name for template substitution.
+
+    Returns:
+        A single-line description suitable for catalog ``spec.primitives``.
+    """
+    text = (tool.title or tool.description or "").strip()
+    first_line = text.split("\n", 1)[0].strip()
+    if brand_long is not None:
+        first_line = Template(first_line).safe_substitute(container_brand_long=brand_long)
+    return _truncate_description(first_line)
+
+
+def _truncate_description(first_line: str) -> str:
+    """Truncate long descriptions at a word boundary."""
+    if len(first_line) <= _DESCRIPTION_MAX_LENGTH:
+        return first_line
+    last_space = first_line.rfind(" ", 80, 99)
+    truncate_at = last_space + 1 if last_space != -1 else 99
+    return first_line[:truncate_at] + "…"
+
+
+def _list_mounted_tools() -> list[ToolDescriptionSource]:
+    """Register, mount, and list tools using the same naming as InsightsMCPServer."""
+    temp_root = InsightsMCP(name="temp", toolset_name="temp", api_path="")
+    for mcp in _get_mcps():
+        try:
+            temp_sub = type(mcp)()  # type: ignore[call-arg]
+            temp_sub.register_tools()
+            temp_root.mount(temp_sub, prefix=f"{mcp.toolset_name}_")
+        except (NotImplementedError, TypeError, ValueError):
+            temp_root.mount(mcp, prefix=f"{mcp.toolset_name}_")
+
+    return list(asyncio.run(temp_root.list_tools()))
+
+
+def collect_tool_primitives(*, brand_long: str = "Red Hat Lightspeed") -> list[dict[str, str]]:
+    """Collect tool primitives from all registered MCP toolsets.
+
+    Compass ``spec.primitives`` entries only support ``type``, ``name``, and
+    ``description`` — there is no separate toolset/group field. Toolset context
+    is encoded in ``name`` only (e.g. ``planning__get_upcoming_changes``).
+
+    Args:
+        brand_long: Brand name substituted for ``$container_brand_long`` in descriptions.
+
+    Returns:
+        Sorted list of primitive dicts with ``type``, ``name``, and ``description`` keys.
+    """
+    return [
+        {
+            "type": "tool",
+            "name": tool.name,
+            "description": catalog_tool_description(tool, brand_long=brand_long),
+        }
+        for tool in sorted(_list_mounted_tools(), key=lambda tool_item: tool_item.name)
+    ]

--- a/src/insights_mcp/server.py
+++ b/src/insights_mcp/server.py
@@ -15,31 +15,11 @@ import requests
 from fastmcp import FastMCP
 from mcp.types import Icon, ToolAnnotations
 
-from advisor_mcp.server import mcp_server as AdvisorMCP
-from content_sources_mcp.server import mcp as ContentSourcesMCP
-from image_builder_mcp.server import mcp_server as ImageBuilderMCP
 from insights_mcp import __version__, config
 from insights_mcp.catalog_tools import catalog_tool_description
 from insights_mcp.mcp import InsightsMCP
 from insights_mcp.oauth import create_oauth_provider
-from inventory_mcp.server import mcp as InventoryMCP
-from planning_mcp.server import mcp as PlanningMCP
-from rbac_mcp.server import mcp as RbacMCP
-from remediations_mcp.server import mcp as RemediationsMCP
-from rhsm_mcp.server import mcp as RhsmMCP
-from vulnerability_mcp.server import mcp as VulnerabilityMCP
-
-MCPS: list[InsightsMCP] = [
-    ImageBuilderMCP,
-    RhsmMCP,
-    VulnerabilityMCP,
-    RemediationsMCP,
-    AdvisorMCP,
-    InventoryMCP,
-    ContentSourcesMCP,
-    RbacMCP,
-    PlanningMCP,
-]
+from insights_mcp.toolsets import MCPS
 
 
 def _format_server_tools(

--- a/src/insights_mcp/server.py
+++ b/src/insights_mcp/server.py
@@ -19,6 +19,7 @@ from advisor_mcp.server import mcp_server as AdvisorMCP
 from content_sources_mcp.server import mcp as ContentSourcesMCP
 from image_builder_mcp.server import mcp_server as ImageBuilderMCP
 from insights_mcp import __version__, config
+from insights_mcp.catalog_tools import catalog_tool_description
 from insights_mcp.mcp import InsightsMCP
 from insights_mcp.oauth import create_oauth_provider
 from inventory_mcp.server import mcp as InventoryMCP
@@ -189,21 +190,6 @@ class InsightsMCPServer(FastMCP):  # pylint: disable=too-many-instance-attribute
             self.mount(mcp, prefix=f"{mcp.toolset_name}_")
 
 
-def _get_tool_description(tool: Any) -> str:
-    """Extract first line of description or title for a tool."""
-    desc = getattr(tool, "description", None) or ""
-    title = getattr(tool, "title", None) or ""
-    text = (desc or title).strip()
-    if not text:
-        return ""
-    first_line = text.split("\n", 1)[0].strip()
-    # Truncate very long lines
-    if len(first_line) > 100:
-        last_space = first_line.rfind(" ", 80, 99)
-        first_line = first_line[: last_space + 1 if last_space != -1 else 99] + "…"
-    return first_line
-
-
 def _collect_readwrite_tools_from_temp_root(allowed_mcps: list[str]) -> dict[str, list[tuple[str, str]]]:
     """Collect read-write tools from a temporary InsightsMCP container.
 
@@ -230,7 +216,7 @@ def _collect_readwrite_tools_from_temp_root(allowed_mcps: list[str]) -> dict[str
                 toolset_name = name.split("_", 1)[0]
                 if toolset_name not in rw_by_toolset:
                     rw_by_toolset[toolset_name] = []
-                desc = _get_tool_description(tool)
+                desc = catalog_tool_description(tool)
                 rw_by_toolset[toolset_name].append((name, desc))
     for toolset_name in rw_by_toolset:
         rw_by_toolset[toolset_name] = sorted(rw_by_toolset[toolset_name], key=lambda x: x[0])

--- a/src/insights_mcp/toolsets.py
+++ b/src/insights_mcp/toolsets.py
@@ -1,0 +1,24 @@
+"""Registered MCP toolsets mounted by InsightsMCPServer."""
+
+from advisor_mcp.server import mcp_server as AdvisorMCP
+from content_sources_mcp.server import mcp as ContentSourcesMCP
+from image_builder_mcp.server import mcp_server as ImageBuilderMCP
+from insights_mcp.mcp import InsightsMCP
+from inventory_mcp.server import mcp as InventoryMCP
+from planning_mcp.server import mcp as PlanningMCP
+from rbac_mcp.server import mcp as RbacMCP
+from remediations_mcp.server import mcp as RemediationsMCP
+from rhsm_mcp.server import mcp as RhsmMCP
+from vulnerability_mcp.server import mcp as VulnerabilityMCP
+
+MCPS: list[InsightsMCP] = [
+    ImageBuilderMCP,
+    RhsmMCP,
+    VulnerabilityMCP,
+    RemediationsMCP,
+    AdvisorMCP,
+    InventoryMCP,
+    ContentSourcesMCP,
+    RbacMCP,
+    PlanningMCP,
+]

--- a/tests/test_catalog_tools.py
+++ b/tests/test_catalog_tools.py
@@ -1,8 +1,9 @@
-"""Tests for Compass catalog tool primitive collection."""
+"""Tests for Compass catalog tool primitive collection and catalog-info generation."""
 
 from __future__ import annotations
 
 from fastmcp.tools import Tool
+from generate_catalog_info import format_primitives_yaml
 
 from insights_mcp.catalog_tools import catalog_tool_description, collect_tool_primitives
 
@@ -20,22 +21,16 @@ def _make_tool(*, docstring: str = "", title: str | None = None) -> Tool:
     return tool
 
 
-def test_catalog_tool_description_prefers_title() -> None:
-    """Title is used when both title and description are present."""
-    tool = _make_tool(docstring="Longer description line", title="Short title")
-    assert catalog_tool_description(tool) == "Short title"
+def test_catalog_tool_description() -> None:
+    """Title, description fallback, and brand substitution."""
+    title_tool = _make_tool(docstring="Longer description line", title="Short title")
+    assert catalog_tool_description(title_tool) == "Short title"
 
+    description_tool = _make_tool(docstring="List CVEs affecting the account.")
+    assert catalog_tool_description(description_tool) == "List CVEs affecting the account."
 
-def test_catalog_tool_description_uses_description_when_title_missing() -> None:
-    """Description first line is used when title is not set."""
-    tool = _make_tool(docstring="List CVEs affecting the account.")
-    assert catalog_tool_description(tool) == "List CVEs affecting the account."
-
-
-def test_catalog_tool_description_substitutes_brand_long() -> None:
-    """$container_brand_long placeholders are substituted for catalog output."""
-    tool = _make_tool(title="Get $container_brand_long inventory")
-    assert catalog_tool_description(tool, brand_long="Red Hat Lightspeed") == "Get Red Hat Lightspeed inventory"
+    brand_tool = _make_tool(title="Get $container_brand_long inventory")
+    assert catalog_tool_description(brand_tool, brand_long="Red Hat Lightspeed") == "Get Red Hat Lightspeed inventory"
 
 
 def test_catalog_tool_description_truncates_long_lines() -> None:
@@ -47,8 +42,8 @@ def test_catalog_tool_description_truncates_long_lines() -> None:
     assert result.endswith("…")
 
 
-def test_collect_tool_primitives_shape_and_uniqueness() -> None:
-    """Collected primitives have required fields, unique prefixed names."""
+def test_collect_tool_primitives() -> None:
+    """Mounted toolsets export unique, prefixed, non-empty tool primitives."""
     primitives = collect_tool_primitives()
 
     assert primitives, "Expected at least one tool primitive from mounted toolsets"
@@ -57,30 +52,26 @@ def test_collect_tool_primitives_shape_and_uniqueness() -> None:
     assert len(names) == len(set(names))
 
     for primitive in primitives:
-        assert primitive == {
-            "type": "tool",
-            "name": primitive["name"],
-            "description": primitive["description"],
-        }
         assert primitive["type"] == "tool"
         assert primitive["description"]
         assert "__" in primitive["name"]
 
-
-def test_collect_tool_primitives_includes_inventory_list_hosts() -> None:
-    """A known inventory tool is exported with a non-empty description."""
-    primitives = collect_tool_primitives()
-    inventory_list_hosts = next(
-        (primitive for primitive in primitives if primitive["name"] == "inventory__list_hosts"),
-        None,
-    )
-    assert inventory_list_hosts is not None
-    assert inventory_list_hosts["description"]
-
-
-def test_collect_tool_primitives_includes_distinct_openapi_tools() -> None:
-    """Toolsets with duplicate bare names are exported with unique prefixes."""
-    primitives = collect_tool_primitives()
-    openapi_tools = [primitive["name"] for primitive in primitives if primitive["name"].endswith("__get_openapi")]
+    openapi_tools = [name for name in names if name.endswith("__get_openapi")]
     assert "image-builder__get_openapi" in openapi_tools
     assert "vulnerability__get_openapi" in openapi_tools
+
+
+def test_format_primitives_yaml_inserts_toolset_headings() -> None:
+    """Each toolset gets one comment heading; repeated tools share it."""
+    primitives = [
+        {"type": "tool", "name": "advisor__get_active_rules", "description": "Get active rules"},
+        {"type": "tool", "name": "advisor__get_rule_details", "description": "Get rule details"},
+        {"type": "tool", "name": "image-builder__get_blueprints", "description": "Get blueprints"},
+    ]
+
+    rendered = format_primitives_yaml(primitives)
+
+    assert rendered.count("    # advisor") == 1
+    assert rendered.count("    # image-builder") == 1
+    assert rendered.index("    # advisor") < rendered.index("advisor__get_active_rules")
+    assert rendered.index("    # image-builder") < rendered.index("image-builder__get_blueprints")

--- a/tests/test_catalog_tools.py
+++ b/tests/test_catalog_tools.py
@@ -2,29 +2,33 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+from fastmcp.tools import Tool
 
 from insights_mcp.catalog_tools import catalog_tool_description, collect_tool_primitives
 
 
-def _make_tool(
-    *,
-    name: str = "example_tool",
-    title: str = "",
-    description: str = "",
-) -> SimpleNamespace:
-    return SimpleNamespace(name=name, title=title, description=description)
+def _make_tool(*, docstring: str = "", title: str | None = None) -> Tool:
+    """Build a FastMCP Tool for unit tests."""
+
+    async def stub_tool() -> str:
+        return ""
+
+    stub_tool.__doc__ = docstring
+    tool = Tool.from_function(stub_tool, name="stub_tool")
+    if title is not None:
+        tool.title = title
+    return tool
 
 
 def test_catalog_tool_description_prefers_title() -> None:
     """Title is used when both title and description are present."""
-    tool = _make_tool(title="Short title", description="Longer description line")
+    tool = _make_tool(docstring="Longer description line", title="Short title")
     assert catalog_tool_description(tool) == "Short title"
 
 
 def test_catalog_tool_description_uses_description_when_title_missing() -> None:
     """Description first line is used when title is not set."""
-    tool = _make_tool(description="List CVEs affecting the account.")
+    tool = _make_tool(docstring="List CVEs affecting the account.")
     assert catalog_tool_description(tool) == "List CVEs affecting the account."
 
 

--- a/tests/test_catalog_tools.py
+++ b/tests/test_catalog_tools.py
@@ -1,0 +1,82 @@
+"""Tests for Compass catalog tool primitive collection."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from insights_mcp.catalog_tools import catalog_tool_description, collect_tool_primitives
+
+
+def _make_tool(
+    *,
+    name: str = "example_tool",
+    title: str = "",
+    description: str = "",
+) -> SimpleNamespace:
+    return SimpleNamespace(name=name, title=title, description=description)
+
+
+def test_catalog_tool_description_prefers_title() -> None:
+    """Title is used when both title and description are present."""
+    tool = _make_tool(title="Short title", description="Longer description line")
+    assert catalog_tool_description(tool) == "Short title"
+
+
+def test_catalog_tool_description_uses_description_when_title_missing() -> None:
+    """Description first line is used when title is not set."""
+    tool = _make_tool(description="List CVEs affecting the account.")
+    assert catalog_tool_description(tool) == "List CVEs affecting the account."
+
+
+def test_catalog_tool_description_substitutes_brand_long() -> None:
+    """$container_brand_long placeholders are substituted for catalog output."""
+    tool = _make_tool(title="Get $container_brand_long inventory")
+    assert catalog_tool_description(tool, brand_long="Red Hat Lightspeed") == "Get Red Hat Lightspeed inventory"
+
+
+def test_catalog_tool_description_truncates_long_lines() -> None:
+    """Very long descriptions are truncated at a word boundary."""
+    long_text = "Word " * 30
+    tool = _make_tool(title=long_text.strip())
+    result = catalog_tool_description(tool)
+    assert len(result) <= 100
+    assert result.endswith("…")
+
+
+def test_collect_tool_primitives_shape_and_uniqueness() -> None:
+    """Collected primitives have required fields, unique prefixed names."""
+    primitives = collect_tool_primitives()
+
+    assert primitives, "Expected at least one tool primitive from mounted toolsets"
+
+    names = [primitive["name"] for primitive in primitives]
+    assert len(names) == len(set(names))
+
+    for primitive in primitives:
+        assert primitive == {
+            "type": "tool",
+            "name": primitive["name"],
+            "description": primitive["description"],
+        }
+        assert primitive["type"] == "tool"
+        assert primitive["description"]
+        assert "__" in primitive["name"]
+
+
+def test_collect_tool_primitives_includes_inventory_list_hosts() -> None:
+    """A known inventory tool is exported with a non-empty description."""
+    primitives = collect_tool_primitives()
+    inventory_list_hosts = next(
+        (primitive for primitive in primitives if primitive["name"] == "inventory__list_hosts"),
+        None,
+    )
+    assert inventory_list_hosts is not None
+    assert inventory_list_hosts["description"]
+
+
+def test_collect_tool_primitives_includes_distinct_openapi_tools() -> None:
+    """Toolsets with duplicate bare names are exported with unique prefixes."""
+    primitives = collect_tool_primitives()
+    openapi_tools = [primitive["name"] for primitive in primitives if primitive["name"].endswith("__get_openapi")]
+    assert "image-builder__get_openapi" in openapi_tools
+    assert "vulnerability__get_openapi" in openapi_tools

--- a/tests/test_cursor_tool_naming.py
+++ b/tests/test_cursor_tool_naming.py
@@ -7,7 +7,7 @@ See README Known Issues section for user-facing documentation.
 
 import asyncio
 
-from insights_mcp.server import MCPS
+from insights_mcp.toolsets import MCPS
 from tests.conftest import TEST_CLIENT_ID, TEST_CLIENT_SECRET
 
 # Cursor uses the mcp.json server name as prefix; one-click install uses this.

--- a/tests/test_get_instructions.py
+++ b/tests/test_get_instructions.py
@@ -1,6 +1,7 @@
 """Test get_instructions for read-only vs all-tools modes."""
 
-from insights_mcp.server import MCPS, get_instructions
+from insights_mcp.server import get_instructions
+from insights_mcp.toolsets import MCPS
 
 ADDITIONAL_TOOLS_PHRASE = "Additional tools are available but not enabled"
 


### PR DESCRIPTION
Add `catalog-info.yaml` and tooling to keep it up to date.
The `catalog-info.yaml` represents metadata to be used by the "[catalog/compass](https://catalog.redhat.com/en/software/container-stacks/detail/69441d9d0df8059c340fa3f1)"