### PR TITLE
chore: fix catalog data

### DIFF
--- a/catalog-info.base.yaml
+++ b/catalog-info.base.yaml
@@ -1,11 +1,14 @@
 apiVersion: mcp/v1beta1
 kind: MCPServer
 metadata:
-  name: lightspeed-mcp-server
-  title: Red Hat Lightspeed MCP Server
-  namespace: redhat
-
+  name: red-hat-lightspeed-mcp-server
   description: An MCP server to enable AI agents to query platform data, analyze systems, identify critical vulnerabilities, and perform proactive planning and lifecycle management.
+  namespace: redhat
+  title: Red Hat Lightspeed MCP Server
+  tags:
+    - mcp
+    - lightspeed
+    - administration
 
   annotations:
     github.com/project-slug: RedHatInsights/insights-mcp
@@ -20,11 +23,6 @@ metadata:
     feedback/host: https://redhat.atlassian.net
     feedback/email-to: rh-lightspeed-mcp@redhat.com
 
-  tags:
-    - mcp
-    - lightspeed
-    - administration
-
   links:
     - url: https://github.com/RedHatInsights/insights-mcp/blob/main/README.md
       title: README
@@ -36,21 +34,20 @@ metadata:
       title: View on Red Hat Catalog
       type: documentation
 
-relations:
-  - type: ownedBy
-    targetRef: group:redhat/rh-lightspeed-mcp
-
 spec:
   type: local
-  lifecycle: developer-preview
+  lifecycle: beta
   owner: group:redhat/rh-lightspeed-mcp
+  system: system:uxe/hybrid-cloud-console
+  auth:
+    type: bearer
 
   packages:
     - type: container
-      registry: quay.io
-      name: redhat-services-prod/insights-management-tenant/insights-mcp/red-hat-lightspeed-mcp
+      registry: "quay.io"
+      name: "redhat-services-prod/insights-management-tenant/insights-mcp/red-hat-lightspeed-mcp"
       version: latest
     - type: container
-      registry: ghcr.io
-      name: redhatinsights/red-hat-lightspeed-mcp
+      registry: "ghcr.io"
+      name: "redhatinsights/red-hat-lightspeed-mcp"
       version: latest

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,11 +1,14 @@
 apiVersion: mcp/v1beta1
 kind: MCPServer
 metadata:
-  name: lightspeed-mcp-server
-  title: Red Hat Lightspeed MCP Server
-  namespace: redhat
-
+  name: red-hat-lightspeed-mcp-server
   description: An MCP server to enable AI agents to query platform data, analyze systems, identify critical vulnerabilities, and perform proactive planning and lifecycle management.
+  namespace: redhat
+  title: Red Hat Lightspeed MCP Server
+  tags:
+    - mcp
+    - lightspeed
+    - administration
 
   annotations:
     github.com/project-slug: RedHatInsights/insights-mcp
@@ -20,11 +23,6 @@ metadata:
     feedback/host: https://redhat.atlassian.net
     feedback/email-to: rh-lightspeed-mcp@redhat.com
 
-  tags:
-    - mcp
-    - lightspeed
-    - administration
-
   links:
     - url: https://github.com/RedHatInsights/insights-mcp/blob/main/README.md
       title: README
@@ -36,23 +34,22 @@ metadata:
       title: View on Red Hat Catalog
       type: documentation
 
-relations:
-  - type: ownedBy
-    targetRef: group:redhat/rh-lightspeed-mcp
-
 spec:
   type: local
-  lifecycle: developer-preview
+  lifecycle: beta
   owner: group:redhat/rh-lightspeed-mcp
+  system: system:uxe/hybrid-cloud-console
+  auth:
+    type: bearer
 
   packages:
     - type: container
-      registry: quay.io
-      name: redhat-services-prod/insights-management-tenant/insights-mcp/red-hat-lightspeed-mcp
+      registry: "quay.io"
+      name: "redhat-services-prod/insights-management-tenant/insights-mcp/red-hat-lightspeed-mcp"
       version: latest
     - type: container
-      registry: ghcr.io
-      name: redhatinsights/red-hat-lightspeed-mcp
+      registry: "ghcr.io"
+      name: "redhatinsights/red-hat-lightspeed-mcp"
       version: latest
   primitives:
     # advisor


### PR DESCRIPTION
In order to promote the MCP server to the Compass catalog, we need to adapt the base file that had some typos.
This PR fixes it