### PR TITLE
feat: add CVE and inventory dashboards as MCP Apps

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -117,6 +117,7 @@ Appstreams
 js
 postgresql
 nodejs
+remediatable
 requester's
 Ansible
 CDN

--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -119,8 +119,11 @@ postgresql
 nodejs
 requester's
 Ansible
+CDN
 env
 Mitigations
 permissioned
+SDK
 triaging
+TUI
 UI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,7 @@ insights-mcp --toolset=image-builder,vulnerability # Multiple specific toolsets
 3. Add type annotations and parameter validation
 4. Add behavioral color coding (🟢/🔴) in descriptions
 5. Write unit and integration tests
+6. If the tool includes an interactive UI, follow the [MCP Apps guide in HACKING.md](HACKING.md#mcp-apps)
 
 ### Debugging Authentication
 - Check service account credentials in Red Hat console
@@ -297,5 +298,6 @@ podman run -it --rm insights-mcp /bin/bash
 4. **Code Style**: stick to the settings in `pyproject.toml` and `.editorconfig`
 5. **Dependencies**: Check `pyproject.toml` for current dependencies
 6. **Compliance**: For logging, debug mode, and ISO alignment (27001, 27017, 27018, 42001), see [HACKING.md - Logging and Compliance](HACKING.md#logging-and-compliance)
+7. **MCP Apps**: For adding or maintaining interactive UI apps, see [HACKING.md - MCP Apps](HACKING.md#mcp-apps)
 
 This guide supplements the README with development-specific information for AI coding assistants working on the Insights MCP project. The architecture supports multiple Red Hat Insights service toolsets through a unified server interface.

--- a/HACKING.md
+++ b/HACKING.md
@@ -134,6 +134,147 @@ For multiuser scenarios (SSE/HTTP transports with header-based authentication), 
 
 **Used by:** `InsightsHeadersBasedClient` for SSE/HTTP transports when service account credentials are provided via request headers. JWT Bearer token authentication bypasses the cache since no token exchange is needed.
 
+## MCP Apps
+
+[MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview) is an MCP extension (`io.modelcontextprotocol/ui`) that lets MCP servers return interactive HTML interfaces (data visualizations, forms, dashboards) that render directly in the chat. Clients with MCP Apps support include Cursor, VS Code Copilot, Claude Desktop, and [others](https://modelcontextprotocol.io/extensions/client-matrix). CLI and TUI clients (e.g. Claude Code, Copilot CLI, OpenCode) do not support UI rendering.
+
+### How It Works
+
+1. The server registers an HTML page as a **UI resource** (`@mcp.resource`).
+2. The server registers a **tool that references it** (`@mcp.tool` with `AppConfig`).
+3. When a client calls the tool, the server returns a `ToolResult` with `content` and `structured_content`. To handle clients that don't support UI rendering, the server can use `ctx.client_supports_extension(UI_EXTENSION_ID)` to detect support and adapt the response accordingly.
+4. The app HTML connects to the MCP Apps SDK and can interact with the server in two ways:
+   - Via `ontoolresult` — receives the tool call result.
+   - Via `callServerTool` — invokes MCP tools directly from the HTML (e.g. to fetch additional data or drill into details).
+
+### Adding a New MCP App
+
+#### 1. Create the HTML file
+
+Create `src/<toolset_mcp>/<app_name>.html`.
+
+#### 2. Load the HTML at module level
+
+In `src/<toolset_mcp>/server.py`:
+
+```python
+from importlib import resources
+from pathlib import Path
+
+def _load_my_app_html() -> str:
+    try:
+        return resources.files("my_toolset_mcp").joinpath("my_app.html").read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
+        return (Path(__file__).parent / "my_app.html").read_text(encoding="utf-8")
+
+EMBEDDED_MY_APP_HTML = _load_my_app_html()
+```
+
+#### 3. Define resource and mounted URIs
+
+```python
+MY_APP_RESOURCE_URI = "ui://my-app"
+MY_APP_MOUNTED_URI = "ui://my_toolset_/my-app"
+```
+
+The mounted URI follows the convention `ui://<toolset_name>_/<app-name>`, matching how FastMCP mounts toolset tools.
+
+#### 4. Register the resource
+
+```python
+from fastmcp.apps import AppConfig, ResourceCSP
+
+@mcp.resource(
+    MY_APP_RESOURCE_URI,
+    app=AppConfig(csp=ResourceCSP(resource_domains=["https://unpkg.com"])),
+)
+def my_app_ui() -> str:
+    """My App UI description."""
+    return EMBEDDED_MY_APP_HTML
+```
+
+Since the HTML is embedded in the Python package, external dependencies like PatternFly CSS should be loaded from a CDN rather than bundled inline. The `ResourceCSP` whitelist must include any CDN domains used.
+
+#### 5. Register the tool with a UI resource
+
+```python
+from fastmcp import Context
+from fastmcp.apps import UI_EXTENSION_ID, AppConfig
+from fastmcp.tools import ToolResult
+
+@mcp.tool(
+    annotations={"readOnlyHint": True},
+    app=AppConfig(resource_uri=MY_APP_MOUNTED_URI),
+)
+async def load_my_app(ctx: Context, ...) -> ToolResult:
+    """Render data in the interactive app."""
+    ui_supported = ctx.client_supports_extension(UI_EXTENSION_ID)
+    if not ui_supported:
+        return ToolResult(
+            content="Client does not support MCP Apps.",  # fallback instructions for non-UI clients
+        )
+    return ToolResult(
+        content="...",  # optional message for the model (also available for the HTML via result.content)
+        structured_content={...},  # data for the HTML via result.structuredContent
+    )
+```
+
+
+#### 6. Connect the HTML to MCP Apps SDK
+
+> **Dark mode:** Use CSS variables on `:root` (light) and `[data-theme="dark"]` (dark), toggled by the `onhostcontextchanged` callback. Use `background: transparent` on body to inherit the host app's background.
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@5.4.2/patternfly.min.css">
+
+<script type="module">
+    import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
+        const App = module.App || module.default?.App || module.default;
+        const app = new (App.App || App)({ name: "My App", version: "1.0.0" });
+        app.connect();
+        window.mcpApp = app;
+
+        app.onhostcontextchanged = (ctx) => {
+            const theme = ctx?.theme || "light";
+            document.documentElement.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
+        };
+
+        app.ontoolresult = (result) => {
+            const data = result.structuredContent;  // structured_content from the ToolResult
+            const content = result.content;             // content from the ToolResult
+            // render data
+        };
+    });
+</script>
+```
+
+#### 7. Calling tools from the app
+
+Apps can invoke MCP tools directly for drill-downs or fetching additional data. Only tools on the same MCP server as the resource can be called — cross-server tool calls are not supported.
+
+```javascript
+const result = await window.mcpApp.callServerTool({
+    name: "toolset__tool_name",
+    arguments: { param: "value" }
+});
+const text = result.content?.find(c => c.type === "text")?.text;
+```
+
+#### 8. Add test prompts
+
+Add 1-2 example prompts to `src/<toolset_mcp>/test_prompts.md` that exercise the app.
+
+### Design Resources
+
+- [PatternFly](https://www.patternfly.org/) — CSS framework used for styling MCP Apps in this project
+
+### Existing Apps
+
+Use these as reference implementations:
+
+- **CVE Dashboard**: [`src/vulnerability_mcp/cve_dashboard.html`](src/vulnerability_mcp/cve_dashboard.html) + [`server.py`](src/vulnerability_mcp/server.py)
+- **Inventory Dashboard**: [`src/inventory_mcp/inventory_dashboard.html`](src/inventory_mcp/inventory_dashboard.html) + [`server.py`](src/inventory_mcp/server.py)
+
 ## Important notes
 * When changing some code you might want to use `make build-prod` so the container is built with
   the upstream container tag and you don't need to change it in your MCP client (like VSCode).

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -130,7 +130,7 @@ spec:
       description: "List hosts with filtering and sorting options."
     - type: tool
       name: inventory__load_inventory_dashboard
-      description: "Render host data in the interactive Inventory Dashboard."
+      description: "Show, list, or display fleet inventory in an interactive dashboard."
     # planning
     - type: tool
       name: planning__get_appstreams_lifecycle
@@ -189,4 +189,4 @@ spec:
       description: "Get list of systems in Red Hat Lightspeed Vulnerability inventory."
     - type: tool
       name: vulnerability__load_cve_dashboard
-      description: "Render CVE data in the interactive CVE Dashboard."
+      description: "Show, list, or display CVEs — account-level or for a specific system — in an interactive dashboard."

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -128,6 +128,9 @@ spec:
     - type: tool
       name: inventory__list_hosts
       description: "List hosts with filtering and sorting options."
+    - type: tool
+      name: inventory__load_inventory_dashboard
+      description: "Render host data in the interactive Inventory Dashboard."
     # planning
     - type: tool
       name: planning__get_appstreams_lifecycle
@@ -184,3 +187,6 @@ spec:
     - type: tool
       name: vulnerability__get_systems
       description: "Get list of systems in Red Hat Lightspeed Vulnerability inventory."
+    - type: tool
+      name: vulnerability__load_cve_dashboard
+      description: "Render CVE data in the interactive CVE Dashboard."

--- a/docs/mkdocs/HACKING.md
+++ b/docs/mkdocs/HACKING.md
@@ -134,6 +134,147 @@ For multiuser scenarios (SSE/HTTP transports with header-based authentication), 
 
 **Used by:** `InsightsHeadersBasedClient` for SSE/HTTP transports when service account credentials are provided via request headers. JWT Bearer token authentication bypasses the cache since no token exchange is needed.
 
+## MCP Apps
+
+[MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview) is an MCP extension (`io.modelcontextprotocol/ui`) that lets MCP servers return interactive HTML interfaces (data visualizations, forms, dashboards) that render directly in the chat. Clients with MCP Apps support include Cursor, VS Code Copilot, Claude Desktop, and [others](https://modelcontextprotocol.io/extensions/client-matrix). CLI and TUI clients (e.g. Claude Code, Copilot CLI, OpenCode) do not support UI rendering.
+
+### How It Works
+
+1. The server registers an HTML page as a **UI resource** (`@mcp.resource`).
+2. The server registers a **tool that references it** (`@mcp.tool` with `AppConfig`).
+3. When a client calls the tool, the server returns a `ToolResult` with `content` and `structured_content`. To handle clients that don't support UI rendering, the server can use `ctx.client_supports_extension(UI_EXTENSION_ID)` to detect support and adapt the response accordingly.
+4. The app HTML connects to the MCP Apps SDK and can interact with the server in two ways:
+   - Via `ontoolresult` — receives the tool call result.
+   - Via `callServerTool` — invokes MCP tools directly from the HTML (e.g. to fetch additional data or drill into details).
+
+### Adding a New MCP App
+
+#### 1. Create the HTML file
+
+Create `src/<toolset_mcp>/<app_name>.html`.
+
+#### 2. Load the HTML at module level
+
+In `src/<toolset_mcp>/server.py`:
+
+```python
+from importlib import resources
+from pathlib import Path
+
+def _load_my_app_html() -> str:
+    try:
+        return resources.files("my_toolset_mcp").joinpath("my_app.html").read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
+        return (Path(__file__).parent / "my_app.html").read_text(encoding="utf-8")
+
+EMBEDDED_MY_APP_HTML = _load_my_app_html()
+```
+
+#### 3. Define resource and mounted URIs
+
+```python
+MY_APP_RESOURCE_URI = "ui://my-app"
+MY_APP_MOUNTED_URI = "ui://my_toolset_/my-app"
+```
+
+The mounted URI follows the convention `ui://<toolset_name>_/<app-name>`, matching how FastMCP mounts toolset tools.
+
+#### 4. Register the resource
+
+```python
+from fastmcp.apps import AppConfig, ResourceCSP
+
+@mcp.resource(
+    MY_APP_RESOURCE_URI,
+    app=AppConfig(csp=ResourceCSP(resource_domains=["https://unpkg.com"])),
+)
+def my_app_ui() -> str:
+    """My App UI description."""
+    return EMBEDDED_MY_APP_HTML
+```
+
+Since the HTML is embedded in the Python package, external dependencies like PatternFly CSS should be loaded from a CDN rather than bundled inline. The `ResourceCSP` whitelist must include any CDN domains used.
+
+#### 5. Register the tool with a UI resource
+
+```python
+from fastmcp import Context
+from fastmcp.apps import UI_EXTENSION_ID, AppConfig
+from fastmcp.tools import ToolResult
+
+@mcp.tool(
+    annotations={"readOnlyHint": True},
+    app=AppConfig(resource_uri=MY_APP_MOUNTED_URI),
+)
+async def load_my_app(ctx: Context, ...) -> ToolResult:
+    """Render data in the interactive app."""
+    ui_supported = ctx.client_supports_extension(UI_EXTENSION_ID)
+    if not ui_supported:
+        return ToolResult(
+            content="Client does not support MCP Apps.",  # fallback instructions for non-UI clients
+        )
+    return ToolResult(
+        content="...",  # optional message for the model (also available for the HTML via result.content)
+        structured_content={...},  # data for the HTML via result.structuredContent
+    )
+```
+
+
+#### 6. Connect the HTML to MCP Apps SDK
+
+> **Dark mode:** Use CSS variables on `:root` (light) and `[data-theme="dark"]` (dark), toggled by the `onhostcontextchanged` callback. Use `background: transparent` on body to inherit the host app's background.
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@5.4.2/patternfly.min.css">
+
+<script type="module">
+    import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
+        const App = module.App || module.default?.App || module.default;
+        const app = new (App.App || App)({ name: "My App", version: "1.0.0" });
+        app.connect();
+        window.mcpApp = app;
+
+        app.onhostcontextchanged = (ctx) => {
+            const theme = ctx?.theme || "light";
+            document.documentElement.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
+        };
+
+        app.ontoolresult = (result) => {
+            const data = result.structuredContent;  // structured_content from the ToolResult
+            const content = result.content;             // content from the ToolResult
+            // render data
+        };
+    });
+</script>
+```
+
+#### 7. Calling tools from the app
+
+Apps can invoke MCP tools directly for drill-downs or fetching additional data. Only tools on the same MCP server as the resource can be called — cross-server tool calls are not supported.
+
+```javascript
+const result = await window.mcpApp.callServerTool({
+    name: "toolset__tool_name",
+    arguments: { param: "value" }
+});
+const text = result.content?.find(c => c.type === "text")?.text;
+```
+
+#### 8. Add test prompts
+
+Add 1-2 example prompts to `src/<toolset_mcp>/test_prompts.md` that exercise the app.
+
+### Design Resources
+
+- [PatternFly](https://www.patternfly.org/) — CSS framework used for styling MCP Apps in this project
+
+### Existing Apps
+
+Use these as reference implementations:
+
+- **CVE Dashboard**: [`src/vulnerability_mcp/cve_dashboard.html`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/vulnerability_mcp/cve_dashboard.html) + [`server.py`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/vulnerability_mcp/server.py)
+- **Inventory Dashboard**: [`src/inventory_mcp/inventory_dashboard.html`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/inventory_mcp/inventory_dashboard.html) + [`server.py`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/inventory_mcp/server.py)
+
 ## Important notes
 * When changing some code you might want to use `make build-prod` so the container is built with
   the upstream container tag and you don't need to change it in your MCP client (like VSCode).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ where = ["src", "scripts"]
 
 [tool.setuptools.package-data]
 insights_mcp = ["assets/*.png"]
+inventory_mcp = ["*.html"]
+vulnerability_mcp = ["*.html"]
 
 [tool.pylint.format]
 max-line-length = 120

--- a/src/inventory_mcp/inventory_dashboard.html
+++ b/src/inventory_mcp/inventory_dashboard.html
@@ -198,42 +198,9 @@
             };
 
             app.ontoolresult = (result) => {
-                let hostArray = null;
-
-                // Check structuredContent first (Approach 4 — data separate from text)
                 const sc = result.structuredContent;
-                if (sc) {
-                    const arr = sc.results || sc.data;
-                    if (arr && Array.isArray(arr)) {
-                        hostArray = arr;
-                    }
-                }
-
-                // Fall back to text content
-                if (!hostArray) {
-                    const text = result.content?.find(c => c.type === "text")?.text;
-                    if (text) {
-                        try {
-                            let data = JSON.parse(text);
-                            if (data.content && Array.isArray(data.content)) {
-                                const innerText = data.content.find(c => c.type === "text")?.text;
-                                if (innerText) {
-                                    try { data = JSON.parse(innerText); } catch {}
-                                }
-                            }
-                            const arr = data.results || data.data;
-                            if (arr && Array.isArray(arr)) {
-                                hostArray = arr;
-                            }
-                        } catch { /* initial result may not be JSON */ }
-                    }
-                }
-
-                if (hostArray) {
-                    allHosts = hostArray;
-                    totalHosts = allHosts.length;
-                    document.getElementById("total-count").textContent = totalHosts + " systems";
-                    applyFiltersAndRender();
+                if (sc && sc.query) {
+                    fetchHostData(sc.query);
                 }
             };
         }).catch(err => {
@@ -328,6 +295,33 @@
                 showError(e.message || "Tool call failed");
                 return null;
             }
+        }
+
+        async function fetchHostData(query) {
+            document.getElementById("host-list").innerHTML = '<div class="loading">Loading hosts...</div>';
+            const args = {};
+            if (query.hostname_or_id) args.hostname_or_id = query.hostname_or_id;
+            if (query.display_name) args.display_name = query.display_name;
+            if (query.fqdn) args.fqdn = query.fqdn;
+            if (query.tags) args.tags = query.tags;
+            if (query.staleness) args.staleness = query.staleness;
+            if (query.registered_with) args.registered_with = query.registered_with;
+            if (query.provider_type) args.provider_type = query.provider_type;
+            args.per_page = query.per_page || 10;
+            args.page = query.page || 1;
+            if (query.order_by) {
+                args.order_by = query.order_by;
+                args.order_how = query.order_how || "ASC";
+            }
+            const result = await callTool("inventory__list_hosts", args);
+            if (!result || !result.results) {
+                showError("No host data received");
+                return;
+            }
+            allHosts = result.results;
+            totalHosts = allHosts.length;
+            document.getElementById("total-count").textContent = totalHosts + " systems";
+            applyFiltersAndRender();
         }
 
         function stalenessInfo(host) {

--- a/src/inventory_mcp/inventory_dashboard.html
+++ b/src/inventory_mcp/inventory_dashboard.html
@@ -1,0 +1,546 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inventory Dashboard</title>
+    <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@5.4.2/patternfly.min.css">
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: var(--pf-v5-global--FontFamily--text); font-size: 13px; padding: 12px; background: #e0e0e0; min-height: 100vh; }
+        .header { background: #292929; color: #ffffff; padding: 8px 12px; border-radius: 6px; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; }
+        .header-title { font-size: 14px; font-weight: 600; }
+        .header-meta { font-size: 11px; color: #a3a3a3; }
+        .card { background: #ffffff; border-radius: 6px; border: 1px solid #a3a3a3; margin-bottom: 12px; overflow: hidden; }
+        .card-title { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; font-weight: 600; font-size: 13px; display: flex; align-items: center; gap: 8px; }
+        .card-body { padding: 0; }
+        .alert-danger { background: #fce3e3; border: 1px solid #a60000; color: #a60000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; }
+        .host-row { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; cursor: pointer; transition: background 0.1s; }
+        .host-row:hover { background: #f2f2f2; }
+        .host-row:last-child { border-bottom: none; }
+        .host-name { font-weight: 600; font-size: 13px; color: #292929; }
+        .host-meta { font-size: 11px; color: #4d4d4d; margin-top: 2px; }
+        .staleness { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 10px; font-weight: 600; color: #ffffff; }
+        .staleness-fresh { background: #3d7317; }
+        .staleness-stale { background: #a60000; }
+        .staleness-warning { background: #ca6c0f; }
+        .staleness-unknown { background: #a3a3a3; }
+        .detail-grid { display: grid; grid-template-columns: 120px 1fr; gap: 4px 12px; padding: 12px; font-size: 12px; }
+        .detail-label { color: #4d4d4d; font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: 0.5px; }
+        .detail-value { color: #292929; word-break: break-word; }
+        .btn { padding: 4px 12px; border: none; border-radius: 4px; font-size: 12px; font-weight: 600; cursor: pointer; transition: opacity 0.1s; }
+        .btn:hover { opacity: 0.85; }
+        .btn-back { background: #e0e0e0; color: #292929; }
+        .btn-secondary { background: #292929; color: #ffffff; }
+        .pagination { padding: 8px 12px; display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: #4d4d4d; border-top: 1px solid #e0e0e0; }
+        .loading { text-align: center; padding: 24px; color: #4d4d4d; font-size: 12px; }
+        .search-bar { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; display: flex; gap: 4px; align-items: center; }
+        .search-bar input { flex: 1; padding: 4px 8px; border: 1px solid #a3a3a3; border-radius: 4px; font-size: 12px; font-family: inherit; }
+        .nic-row { font-size: 11px; margin-bottom: 2px; }
+        .sev-critical { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#ffffff;background:#a60000; }
+        .sev-important { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#ffffff;background:#ca6c0f; }
+        .sev-moderate { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#292929;background:#dca614; }
+        .sev-low { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#ffffff;background:#a3a3a3; }
+        .filter-btn { padding: 2px 8px; border: 1px solid #a3a3a3; border-radius: 12px; font-size: 11px; cursor: pointer; background: #ffffff; color: #4d4d4d; transition: all 0.1s; }
+        .filter-btn.active { background: #292929; color: #ffffff; border-color: #292929; }
+        .filter-btn:hover { border-color: #292929; }
+        .hidden { display: none !important; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <span class="header-title"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAdnJLH8AAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+kHHQcvBP3yWUkAAASbSURBVGje7dl5iFVVHAfwz5k3Y+OS5jNN29Boo73Esn0RKouIVtqJVuwPkQiigooWKdIsqKiICoMKIioKyRawohXbixYyKiTavNrY4ujMO/1xjvEcxnlvxvfGgvnCgffuPffc3/ec334ZwhCG8L9GaObiBSMxFh1YXSb+ZwgUbIuTMREf4rUyK6vu74ZbMRU/4V28gvfwa6PIhAEKPxEPY2a+1JkFeyKT2RFXYVqPR9fgK7yIZ/FROV0bdALX4ZZeblXwF4bl0RdW4jU8hlfL/D4oBPLuL8Y+DVLjNXgb92FROW1A3WgZwAunS/rdKLTjaCzEAwVTmkagSPNPxBZNcFrDcR7uKRjXrBPYAUc12bUfi+OaReBw/TziAaAVRzScQJEWPgGlQQiw+xaMbvQJ7IRDBylDmJLVtXEEvuWoWOeiDcA47NFIAiNv57TVhDA4BFpxQL0Te+p6wJaYgAkjGHs9e93N9P0xK0e/2HwS+xe010o1WqsEH4XDsp+fhu0xppMthtPSSekOjCaeTWhpPoldc6L4XU0CBXvhpux/R1RPiPgly7oS1xJ+JV6GUYTu5hGYiF1qEWjJae9DOKWn8OuTpWrH34G5hNn4glhqXlExvLMOO2jBbBy0sQkRM7Bzlcasw9OEc3A/sWgSkU9TLdHa15zS1SzQR+4R080wAksI6zbMh8MSwts5uk3KatUI++jGI5S2ZvHXrOjrBMbUWiziTMIcYnuPe12p1AqzCWdgAfEz4tq8df09mZCfe4e4iF1m8eSfXFFQ7nV+wSfYu56F1+JB4nzCqj7mjSdOzQnNVEzGVoRhNQJPd3Io8SXMT8EzPEw8le4uluBGvFVdjoaCebiyno0KueRaTJyLz2o8E5JKxe1yHjIl+ea4dbqulPn8TeVnwldYii8JnXmNO+m+hFJX+rsc1+DxchKFIiVO3xTZGOsZvxM/pjKLyri0UOzPCMRWYlsepY3MG0Z8gkrHhu8vCi7YoKQskieah7b+pLFdeJ/4KF7CigY7okOIC7MT6eEUfsRZZd4IVVH4LlzUX29YyrbxKfE5vIxlVSowUOxJXIADCZXepyzCuaEqlZiAe3HaQFx6KdvHL8QPcrthaQ6jqwhddZ7qJOJMXJ7C8MaEhz9xceiRyG2D23Jt2jrQNkcpe5QO4vJ0IpYRf0gEQwdxTVKL0EZlLGHH3OaYlgw+rN+QGlgYeslGR2evNKeeGFGLTEvVcXZnu1lH7MqXS8mQ/3WxlfoEX483Qx/l40m4Afs2uym7CVH79V7jSpmuMs/kBO+epMaNRbW/3AQsC3UU8204MqvUjNyI+i9gDS4N/ehKjMrN3Mty4bO5ibyB0wfSGx2NY3B+bgmO3QzCF7iwzPOb8n2gHfvh1Hwyu6rdkW4EVkrd8QfKVEIDtiJI8WM6js/qtVPudTYSFenbw814oZy8cmNzl9z8HZ/T84NTJmD3XN+OHOD7OlKm4ik8VU550KB9IxuW2zOTs4rtnH9PzLYzMqvd+k7NWvyB3/B9FnwpPt/YB5CwGayvRWrPt+fRVkWgK5UH/kZneVDaT0MYwhA2K/4BI+BgELD+CNsAAAAASUVORK5CYII=" alt="Red Hat" style="height:16px;vertical-align:middle;margin-right:6px;">Red Hat Lightspeed — Inventory</span>
+        <span class="header-meta" id="total-count"></span>
+    </div>
+
+    <div id="alert" class="alert-danger hidden"></div>
+
+    <!-- Host List View -->
+    <div id="view-list">
+        <div class="card">
+            <div class="card-title">Fleet</div>
+            <div class="search-bar">
+                <input type="text" id="search-input" placeholder="Search by hostname or FQDN" onkeydown="if(event.key==='Enter')searchHosts()">
+                <button class="btn btn-secondary" onclick="searchHosts()" style="padding:4px 8px;">Search</button>
+                <button class="btn btn-back" onclick="clearSearch()" style="padding:4px 8px;">Clear</button>
+            </div>
+            <div class="filters" style="padding:8px 12px;border-bottom:1px solid #e0e0e0;display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
+                <span style="font-size:11px;color:#4d4d4d;">Staleness:</span>
+                <button class="filter-btn active" data-staleness="" onclick="filterStaleness(this)">All</button>
+                <button class="filter-btn" data-staleness="fresh" onclick="filterStaleness(this)">Fresh</button>
+                <button class="filter-btn" data-staleness="stale" onclick="filterStaleness(this)">Stale</button>
+                <button class="filter-btn" data-staleness="stale_warning" onclick="filterStaleness(this)">Stale warning</button>
+                <span style="margin-left:8px;border-left:1px solid #a3a3a3;padding-left:8px;">
+                    <label style="font-size:11px;color:#4d4d4d;">Sort:
+                        <select id="sort-select" onchange="changeSort()" style="font-size:11px;border:1px solid #a3a3a3;border-radius:4px;padding:1px 4px;font-family:inherit;">
+                            <option value="display_name" data-dir="ASC">Name (A-Z)</option>
+                            <option value="display_name" data-dir="DESC">Name (Z-A)</option>
+                            <option value="updated" data-dir="DESC" selected>Updated (newest)</option>
+                            <option value="updated" data-dir="ASC">Updated (oldest)</option>
+                            <option value="created" data-dir="DESC">Created (newest)</option>
+                            <option value="created" data-dir="ASC">Created (oldest)</option>
+                        </select>
+                    </label>
+                </span>
+            </div>
+            <div class="card-body" id="host-list">
+                <div class="loading">Loading hosts...</div>
+            </div>
+            <div class="pagination hidden" id="pagination">
+                <span id="page-info"></span>
+                <div id="page-buttons" style="display:flex;gap:2px;align-items:center;flex-wrap:wrap;"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Host Detail View -->
+    <div id="view-detail" class="hidden">
+        <div class="card">
+            <div class="card-title">
+                <button class="btn btn-back" onclick="showList()">&#8592; Back</button>
+                <span id="detail-host-name"></span>
+            </div>
+            <div class="card-body" id="host-detail">
+                <div class="loading">Loading host details...</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Host CVEs View -->
+    <div id="view-cves" class="hidden">
+        <div class="card">
+            <div class="card-title">
+                <button class="btn btn-back" onclick="showDetail(window.currentHostId)">&#8592; Back</button>
+                <span id="cves-host-name"></span>
+            </div>
+            <div class="card-body" id="host-cves">
+                <div class="loading">Loading CVEs...</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- CVE Detail View -->
+    <div id="view-cve-detail" class="hidden">
+        <div class="card">
+            <div class="card-title">
+                <button class="btn btn-back" onclick="showHostCves(window.currentHostId)">&#8592; Back</button>
+                <span id="cve-detail-id"></span>
+            </div>
+            <div class="card-body" id="cve-detail-content">
+                <div class="loading">Loading CVE details...</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- System Profile View -->
+    <div id="view-profile" class="hidden">
+        <div class="card">
+            <div class="card-title">
+                <button class="btn btn-back" onclick="showDetail(window.currentHostId)">&#8592; Back</button>
+                <span id="profile-host-name"></span>
+            </div>
+            <div class="card-body" id="system-profile">
+                <div class="loading">Loading system profile...</div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
+            const App = module.App || module.default?.App || module.default;
+            const app = new (App.App || App)({ name: "Inventory Dashboard", version: "1.0.0" });
+            app.connect();
+            window.mcpApp = app;
+            app.ontoolresult = (result) => {
+                let hostArray = null;
+
+                // Check structuredContent first (Approach 4 — data separate from text)
+                const sc = result.structuredContent;
+                if (sc) {
+                    const arr = sc.results || sc.data;
+                    if (arr && Array.isArray(arr)) {
+                        hostArray = arr;
+                    }
+                }
+
+                // Fall back to text content
+                if (!hostArray) {
+                    const text = result.content?.find(c => c.type === "text")?.text;
+                    if (text) {
+                        try {
+                            let data = JSON.parse(text);
+                            if (data.content && Array.isArray(data.content)) {
+                                const innerText = data.content.find(c => c.type === "text")?.text;
+                                if (innerText) {
+                                    try { data = JSON.parse(innerText); } catch {}
+                                }
+                            }
+                            const arr = data.results || data.data;
+                            if (arr && Array.isArray(arr)) {
+                                hostArray = arr;
+                            }
+                        } catch { /* initial result may not be JSON */ }
+                    }
+                }
+
+                if (hostArray) {
+                    allHosts = hostArray;
+                    totalHosts = allHosts.length;
+                    document.getElementById("total-count").textContent = totalHosts + " systems";
+                    applyFiltersAndRender();
+                }
+            };
+        }).catch(err => {
+            showError("Failed to load MCP Apps SDK: " + err.message);
+        });
+
+        let allHosts = [];
+        let currentPage = 1;
+        let currentPerPage = 10;
+        let currentSearch = "";
+        let currentStalenessFilter = "";
+        let currentOrderBy = "updated";
+        let currentOrderHow = "DESC";
+        let totalHosts = 0;
+        window.currentHostId = "";
+        window.currentHostName = "";
+
+        function applyFiltersAndRender() {
+            let filtered = allHosts;
+            if (currentSearch) {
+                const q = currentSearch.toLowerCase();
+                filtered = filtered.filter(h => {
+                    const name = (h.display_name || "").toLowerCase();
+                    const fqdn = (h.fqdn || "").toLowerCase();
+                    const id = (h.id || "").toLowerCase();
+                    return name.includes(q) || fqdn.includes(q) || id.includes(q);
+                });
+            }
+            if (currentStalenessFilter) {
+                filtered = filtered.filter(h => {
+                    const s = stalenessInfo(h).label.toLowerCase().replace(" ", "_");
+                    return s === currentStalenessFilter;
+                });
+            }
+            filtered.sort((a, b) => {
+                let va, vb;
+                if (currentOrderBy === "display_name") { va = (a.display_name || "").toLowerCase(); vb = (b.display_name || "").toLowerCase(); }
+                else if (currentOrderBy === "updated") { va = a.updated || ""; vb = b.updated || ""; }
+                else if (currentOrderBy === "created") { va = a.created || ""; vb = b.created || ""; }
+                else { va = ""; vb = ""; }
+                const desc = currentOrderHow === "DESC";
+                if (va < vb) return desc ? 1 : -1;
+                if (va > vb) return desc ? -1 : 1;
+                return 0;
+            });
+            const start = (currentPage - 1) * currentPerPage;
+            const page = filtered.slice(start, start + currentPerPage);
+            renderHostList({ results: page, total: filtered.length });
+        }
+
+        window.filterStaleness = function(btn) {
+            document.querySelectorAll(".filter-btn").forEach(b => b.classList.remove("active"));
+            btn.classList.add("active");
+            currentStalenessFilter = btn.dataset.staleness;
+            currentPage = 1;
+            applyFiltersAndRender();
+        }
+
+        window.changeSort = function() {
+            const sel = document.getElementById("sort-select");
+            const opt = sel.options[sel.selectedIndex];
+            currentOrderBy = opt.value;
+            currentOrderHow = opt.dataset.dir;
+            currentPage = 1;
+            applyFiltersAndRender();
+        }
+
+        function showError(msg) {
+            const el = document.getElementById("alert");
+            el.textContent = msg;
+            el.classList.remove("hidden");
+        }
+
+        function hideError() {
+            document.getElementById("alert").classList.add("hidden");
+        }
+
+        function showView(id) {
+            ["view-list", "view-detail", "view-cves", "view-cve-detail", "view-profile"].forEach(v => {
+                document.getElementById(v).classList.toggle("hidden", v !== id);
+            });
+        }
+
+        async function callTool(name, args) {
+            if (!window.mcpApp) { showError("MCP App not connected"); return null; }
+            try {
+                const result = await window.mcpApp.callServerTool({ name, arguments: args });
+                const text = result.content?.find(c => c.type === "text")?.text;
+                if (!text) { showError("No response from server"); return null; }
+                try { return JSON.parse(text); } catch { showError(text); return null; }
+            } catch (e) {
+                showError(e.message || "Tool call failed");
+                return null;
+            }
+        }
+
+        function stalenessInfo(host) {
+            const now = Date.now();
+            const stale = host.stale_timestamp ? new Date(host.stale_timestamp).getTime() : null;
+            const warning = host.stale_warning_timestamp ? new Date(host.stale_warning_timestamp).getTime() : null;
+            const culled = host.culled_timestamp ? new Date(host.culled_timestamp).getTime() : null;
+
+            if (culled && now > culled) return { label: "Culled", cls: "staleness-stale" };
+            if (warning && now > warning) return { label: "Stale warning", cls: "staleness-warning" };
+            if (stale && now > stale) return { label: "Stale", cls: "staleness-stale" };
+            return { label: "Fresh", cls: "staleness-fresh" };
+        }
+
+        function formatBytes(bytes) {
+            if (!bytes) return "N/A";
+            return (bytes / (1024 * 1024 * 1024)).toFixed(1) + " GB";
+        }
+
+        // --- Host List ---
+
+        window.searchHosts = function() {
+            currentSearch = document.getElementById("search-input").value.trim();
+            currentPage = 1;
+            applyFiltersAndRender();
+        }
+
+        window.clearSearch = function() {
+            document.getElementById("search-input").value = "";
+            currentSearch = "";
+            currentPage = 1;
+            applyFiltersAndRender();
+        }
+
+        function renderHostList(data) {
+            const container = document.getElementById("host-list");
+            const filteredTotal = data.total || 0;
+            document.getElementById("total-count").textContent = filteredTotal + " systems";
+
+            if (!data.results || data.results.length === 0) {
+                container.innerHTML = '<div class="loading">No hosts found.</div>';
+                document.getElementById("pagination").classList.add("hidden");
+                return;
+            }
+
+            container.innerHTML = data.results.map(host => {
+                const staleness = stalenessInfo(host);
+                return `<div class="host-row" onclick="showDetail('${host.id}')">
+                    <div style="display:flex;justify-content:space-between;align-items:center;">
+                        <div>
+                            <span class="host-name">${host.display_name || host.fqdn || host.id}</span>
+                            <div class="host-meta">${host.fqdn || "No FQDN"}</div>
+                        </div>
+                        <span class="staleness ${staleness.cls}">${staleness.label}</span>
+                    </div>
+                </div>`;
+            }).join("");
+
+            // Pagination
+            const pag = document.getElementById("pagination");
+            pag.classList.remove("hidden");
+            const totalPages = Math.ceil(filteredTotal / currentPerPage);
+            document.getElementById("page-info").textContent = `Page ${currentPage} of ${totalPages}`;
+            renderPageButtons(currentPage, totalPages);
+        }
+
+        function renderPageButtons(current, total) {
+            const container = document.getElementById("page-buttons");
+            const show = new Set([1, total, current, current - 1, current + 1]);
+            const sorted = [...show].filter(p => p >= 1 && p <= total).sort((a, b) => a - b);
+            let html = `<button class="btn btn-back" onclick="goToPage(${current - 1})" ${current === 1 ? 'disabled' : ''}>&laquo;</button>`;
+            let prev = 0;
+            for (const p of sorted) {
+                if (prev && p - prev > 1) html += `<span style="font-size:11px;color:#4d4d4d;padding:0 2px;">...</span>`;
+                html += `<button class="btn ${p === current ? 'btn-secondary' : 'btn-back'}" onclick="goToPage(${p})" style="min-width:28px;padding:4px 6px;">${p}</button>`;
+                prev = p;
+            }
+            html += `<button class="btn btn-back" onclick="goToPage(${current + 1})" ${current === total ? 'disabled' : ''}>&raquo;</button>`;
+            container.innerHTML = html;
+        }
+
+        window.goToPage = function(p) {
+            currentPage = p;
+            applyFiltersAndRender();
+        }
+
+        window.showList = function() {
+            showView("view-list");
+        }
+
+        // --- Host Detail ---
+
+        window.showDetail = async function(hostId) {
+            window.currentHostId = hostId;
+            showView("view-detail");
+            document.getElementById("detail-host-name").textContent = "Loading...";
+            document.getElementById("host-detail").innerHTML = '<div class="loading">Loading host details...</div>';
+
+            const data = await callTool("inventory__get_host_details", { host_ids: hostId });
+            if (!data || !data.results || data.results.length === 0) return;
+
+            const host = data.results[0];
+            window.currentHostName = host.display_name || host.fqdn || hostId;
+            document.getElementById("detail-host-name").textContent = window.currentHostName;
+
+            document.getElementById("host-detail").innerHTML = `
+                <div class="detail-grid">
+                    <span class="detail-label">Display Name</span>
+                    <span class="detail-value">${host.display_name || "N/A"}</span>
+                    <span class="detail-label">FQDN</span>
+                    <span class="detail-value">${host.fqdn || "N/A"}</span>
+                    <span class="detail-label">ID</span>
+                    <span class="detail-value" style="font-size:11px;font-family:monospace;">${host.id}</span>
+                    <span class="detail-label">Created</span>
+                    <span class="detail-value">${new Date(host.created).toLocaleString()}</span>
+                    <span class="detail-label">Updated</span>
+                    <span class="detail-value">${new Date(host.updated).toLocaleString()}</span>
+                    <span class="detail-label">Reporter</span>
+                    <span class="detail-value">${host.reporter || "N/A"}</span>
+                </div>
+                <div style="padding:12px;display:flex;gap:8px;">
+                    <button class="btn btn-secondary" onclick="showProfile('${hostId}')">System Profile</button>
+                    <button class="btn btn-secondary" onclick="showHostCves('${hostId}')">View CVEs</button>
+                </div>
+            `;
+        }
+
+        // --- System Profile ---
+
+        window.showProfile = async function(hostId) {
+            window.currentHostId = hostId;
+            showView("view-profile");
+            document.getElementById("profile-host-name").textContent = window.currentHostName + " — System Profile";
+            document.getElementById("system-profile").innerHTML = '<div class="loading">Loading system profile...</div>';
+
+            const data = await callTool("inventory__get_host_system_profile", { host_ids: hostId });
+            if (!data || !data.results || data.results.length === 0) return;
+
+            const profile = data.results[0].system_profile || {};
+
+            let html = '<div class="detail-grid">';
+
+            if (profile.os_release) {
+                html += `<span class="detail-label">OS</span><span class="detail-value">${profile.os_release}</span>`;
+            }
+            if (profile.arch) {
+                html += `<span class="detail-label">Architecture</span><span class="detail-value">${profile.arch}</span>`;
+            }
+            if (profile.os_kernel_version) {
+                html += `<span class="detail-label">Kernel</span><span class="detail-value">${profile.os_kernel_version}</span>`;
+            }
+            if (profile.number_of_cpus != null) {
+                html += `<span class="detail-label">CPUs</span><span class="detail-value">${profile.number_of_cpus}${profile.cores_per_socket ? ` (${profile.cores_per_socket} cores/socket)` : ""}</span>`;
+            }
+            if (profile.system_memory_bytes != null) {
+                html += `<span class="detail-label">Memory</span><span class="detail-value">${formatBytes(profile.system_memory_bytes)}</span>`;
+            }
+            if (profile.infrastructure_type) {
+                html += `<span class="detail-label">Infrastructure</span><span class="detail-value">${profile.infrastructure_type}${profile.infrastructure_vendor ? ` (${profile.infrastructure_vendor})` : ""}</span>`;
+            }
+            if (profile.bios_vendor) {
+                html += `<span class="detail-label">BIOS</span><span class="detail-value">${profile.bios_vendor}${profile.bios_version ? ` ${profile.bios_version}` : ""}</span>`;
+            }
+            if (profile.network_interfaces && profile.network_interfaces.length > 0) {
+                const nics = profile.network_interfaces.map(nic =>
+                    `<div class="nic-row">${nic.name || "?"}${nic.ipv4_addresses?.length ? `: ${nic.ipv4_addresses.join(", ")}` : ""}</div>`
+                ).join("");
+                html += `<span class="detail-label">Network</span><span class="detail-value">${nics}</span>`;
+            }
+
+            html += '</div>';
+            document.getElementById("system-profile").innerHTML = html;
+        }
+
+        // --- Host CVEs ---
+
+        function severityLabel(impact) {
+            if (typeof impact === "string") return impact;
+            const map = { 7: "Critical", 5: "Important", 4: "Moderate", 2: "Low", 1: "None", 0: "NotSet" };
+            return map[impact] || "Unknown";
+        }
+
+        function severityClass(impact) {
+            const label = (typeof impact === "string" ? impact : severityLabel(impact)).toLowerCase();
+            const map = { critical: "sev-critical", important: "sev-important", moderate: "sev-moderate", low: "sev-low" };
+            return map[label] || "sev-low";
+        }
+
+        window.showHostCves = async function(hostId) {
+            window.currentHostId = hostId;
+            showView("view-cves");
+            document.getElementById("cves-host-name").textContent = window.currentHostName + " — CVEs";
+            document.getElementById("host-cves").innerHTML = '<div class="loading">Loading CVEs...</div>';
+
+            const data = await callTool("vulnerability__get_system_cves", { system_uuid: hostId });
+            if (!data || !data.data) return;
+
+            if (data.data.length === 0) {
+                document.getElementById("host-cves").innerHTML = '<div class="loading">No CVEs found for this host.</div>';
+                return;
+            }
+
+            document.getElementById("host-cves").innerHTML = data.data.map(cve => {
+                const attrs = cve.attributes || {};
+                const impact = attrs.impact || 0;
+                const cvss = parseFloat(attrs.cvss3_score) || parseFloat(attrs.cvss2_score) || "N/A";
+                return `<div class="host-row" onclick="showCveDetail('${cve.id}')">
+                    <div style="display:flex;justify-content:space-between;align-items:center;">
+                        <span style="font-weight:600;font-size:13px;font-family:monospace;color:#292929;">${cve.id}</span>
+                        <div style="display:flex;gap:8px;align-items:center;">
+                            <span class="${severityClass(impact)}">${severityLabel(impact)}</span>
+                            <span style="font-family:monospace;font-size:11px;font-weight:600;">${cvss}</span>
+                        </div>
+                    </div>
+                </div>`;
+            }).join("");
+        }
+
+        // --- CVE Detail ---
+
+        window.showCveDetail = async function(cveId) {
+            showView("view-cve-detail");
+            document.getElementById("cve-detail-id").textContent = cveId;
+            document.getElementById("cve-detail-content").innerHTML = '<div class="loading">Loading CVE details...</div>';
+
+            const data = await callTool("vulnerability__get_cve", { cve: cveId });
+            if (!data || !data.data) return;
+
+            const attrs = data.data.attributes || {};
+            const impact = attrs.impact || 0;
+            const cvss3 = attrs.cvss3_score || "N/A";
+            const cvss2 = attrs.cvss2_score || "N/A";
+            const published = attrs.public_date ? new Date(attrs.public_date).toLocaleDateString() : "N/A";
+            const modified = attrs.modified_date ? new Date(attrs.modified_date).toLocaleDateString() : "N/A";
+            const desc = attrs.description || "No description available.";
+            const advisories = attrs.advisories_list || [];
+            const redhatUrl = `https://access.redhat.com/security/cve/${cveId}`;
+
+            document.getElementById("cve-detail-content").innerHTML = `
+                <div style="padding:12px;">
+                    <p style="margin-bottom:12px;font-size:12px;color:#4d4d4d;">${desc}</p>
+                </div>
+                <div class="detail-grid">
+                    <span class="detail-label">Severity</span>
+                    <span class="detail-value"><span class="${severityClass(impact)}">${severityLabel(impact)}</span></span>
+                    <span class="detail-label">CVSS 3</span>
+                    <span class="detail-value" style="font-family:monospace;font-weight:600;">${cvss3}</span>
+                    <span class="detail-label">CVSS 2</span>
+                    <span class="detail-value" style="font-family:monospace;font-weight:600;">${cvss2}</span>
+                    <span class="detail-label">Published</span>
+                    <span class="detail-value">${published}</span>
+                    <span class="detail-label">Modified</span>
+                    <span class="detail-value">${modified}</span>
+                    <span class="detail-label">Red Hat</span>
+                    <span class="detail-value"><a href="${redhatUrl}" target="_blank" style="color:#ee0000;">${redhatUrl}</a></span>
+                    ${advisories.length ? `<span class="detail-label">Advisories</span><span class="detail-value">${advisories.map(a => `<a href="${a}" target="_blank" style="color:#ee0000;">${a.split('/').pop()}</a>`).join(', ')}</span>` : ''}
+                </div>
+            `;
+        }
+    </script>
+</body>
+</html>

--- a/src/inventory_mcp/inventory_dashboard.html
+++ b/src/inventory_mcp/inventory_dashboard.html
@@ -6,44 +6,84 @@
     <title>Inventory Dashboard</title>
     <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@5.4.2/patternfly.min.css">
     <style>
+        :root {
+            --bg-primary: #ffffff;
+            --bg-secondary: #f2f2f2;
+            --text-primary: #292929;
+            --text-secondary: #4d4d4d;
+            --border-color: #a3a3a3;
+            --border-light: #e0e0e0;
+            --header-bg: #292929;
+            --header-text: #ffffff;
+            --header-meta: #a3a3a3;
+            --row-hover: #f2f2f2;
+            --btn-bg: #e0e0e0;
+            --btn-text: #292929;
+            --input-bg: #ffffff;
+            --input-border: #a3a3a3;
+            --filter-bg: #ffffff;
+            --filter-text: #4d4d4d;
+            --filter-active-bg: #292929;
+            --filter-active-text: #ffffff;
+        }
+        [data-theme="dark"] {
+            --bg-primary: #1a1a1a;
+            --bg-secondary: #2a2a2a;
+            --text-primary: #e0e0e0;
+            --text-secondary: #a3a3a3;
+            --border-color: #4d4d4d;
+            --border-light: #333333;
+            --header-bg: #111111;
+            --header-text: #ffffff;
+            --header-meta: #a3a3a3;
+            --row-hover: #333333;
+            --btn-bg: #333333;
+            --btn-text: #e0e0e0;
+            --input-bg: #2a2a2a;
+            --input-border: #4d4d4d;
+            --filter-bg: #2a2a2a;
+            --filter-text: #a3a3a3;
+            --filter-active-bg: #e0e0e0;
+            --filter-active-text: #1a1a1a;
+        }
         * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: var(--pf-v5-global--FontFamily--text); font-size: 13px; padding: 12px; background: #e0e0e0; min-height: 100vh; }
-        .header { background: #292929; color: #ffffff; padding: 8px 12px; border-radius: 6px; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; }
+        body { font-family: var(--pf-v5-global--FontFamily--text); font-size: 13px; padding: 12px; background: transparent; color: var(--text-primary); min-height: 100vh; }
+        .header { background: var(--header-bg); color: var(--header-text); padding: 8px 12px; border-radius: 6px; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; }
         .header-title { font-size: 14px; font-weight: 600; }
-        .header-meta { font-size: 11px; color: #a3a3a3; }
-        .card { background: #ffffff; border-radius: 6px; border: 1px solid #a3a3a3; margin-bottom: 12px; overflow: hidden; }
-        .card-title { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; font-weight: 600; font-size: 13px; display: flex; align-items: center; gap: 8px; }
+        .header-meta { font-size: 11px; color: var(--header-meta); }
+        .card { background: var(--bg-primary); border-radius: 6px; border: 1px solid var(--border-color); margin-bottom: 12px; overflow: hidden; }
+        .card-title { padding: 8px 12px; border-bottom: 1px solid var(--border-light); font-weight: 600; font-size: 13px; display: flex; align-items: center; gap: 8px; }
         .card-body { padding: 0; }
         .alert-danger { background: #fce3e3; border: 1px solid #a60000; color: #a60000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; }
-        .host-row { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; cursor: pointer; transition: background 0.1s; }
-        .host-row:hover { background: #f2f2f2; }
+        .host-row { padding: 8px 12px; border-bottom: 1px solid var(--border-light); cursor: pointer; transition: background 0.1s; }
+        .host-row:hover { background: var(--row-hover); }
         .host-row:last-child { border-bottom: none; }
-        .host-name { font-weight: 600; font-size: 13px; color: #292929; }
-        .host-meta { font-size: 11px; color: #4d4d4d; margin-top: 2px; }
+        .host-name { font-weight: 600; font-size: 13px; color: var(--text-primary); }
+        .host-meta { font-size: 11px; color: var(--text-secondary); margin-top: 2px; }
         .staleness { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 10px; font-weight: 600; color: #ffffff; }
         .staleness-fresh { background: #3d7317; }
         .staleness-stale { background: #a60000; }
         .staleness-warning { background: #ca6c0f; }
         .staleness-unknown { background: #a3a3a3; }
         .detail-grid { display: grid; grid-template-columns: 120px 1fr; gap: 4px 12px; padding: 12px; font-size: 12px; }
-        .detail-label { color: #4d4d4d; font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: 0.5px; }
-        .detail-value { color: #292929; word-break: break-word; }
+        .detail-label { color: var(--text-secondary); font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: 0.5px; }
+        .detail-value { color: var(--text-primary); word-break: break-word; }
         .btn { padding: 4px 12px; border: none; border-radius: 4px; font-size: 12px; font-weight: 600; cursor: pointer; transition: opacity 0.1s; }
         .btn:hover { opacity: 0.85; }
-        .btn-back { background: #e0e0e0; color: #292929; }
-        .btn-secondary { background: #292929; color: #ffffff; }
-        .pagination { padding: 8px 12px; display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: #4d4d4d; border-top: 1px solid #e0e0e0; }
-        .loading { text-align: center; padding: 24px; color: #4d4d4d; font-size: 12px; }
-        .search-bar { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; display: flex; gap: 4px; align-items: center; }
-        .search-bar input { flex: 1; padding: 4px 8px; border: 1px solid #a3a3a3; border-radius: 4px; font-size: 12px; font-family: inherit; }
+        .btn-back { background: var(--btn-bg); color: var(--btn-text); }
+        .btn-secondary { background: var(--header-bg); color: #ffffff; }
+        .pagination { padding: 8px 12px; display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--text-secondary); border-top: 1px solid var(--border-light); }
+        .loading { text-align: center; padding: 24px; color: var(--text-secondary); font-size: 12px; }
+        .search-bar { padding: 8px 12px; border-bottom: 1px solid var(--border-light); display: flex; gap: 4px; align-items: center; }
+        .search-bar input { flex: 1; padding: 4px 8px; border: 1px solid var(--input-border); border-radius: 4px; font-size: 12px; font-family: inherit; background: var(--input-bg); color: var(--text-primary); }
         .nic-row { font-size: 11px; margin-bottom: 2px; }
         .sev-critical { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#ffffff;background:#a60000; }
         .sev-important { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#ffffff;background:#ca6c0f; }
         .sev-moderate { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#292929;background:#dca614; }
         .sev-low { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#ffffff;background:#a3a3a3; }
-        .filter-btn { padding: 2px 8px; border: 1px solid #a3a3a3; border-radius: 12px; font-size: 11px; cursor: pointer; background: #ffffff; color: #4d4d4d; transition: all 0.1s; }
-        .filter-btn.active { background: #292929; color: #ffffff; border-color: #292929; }
-        .filter-btn:hover { border-color: #292929; }
+        .filter-btn { padding: 2px 8px; border: 1px solid var(--border-color); border-radius: 12px; font-size: 11px; cursor: pointer; background: var(--filter-bg); color: var(--filter-text); transition: all 0.1s; }
+        .filter-btn.active { background: var(--filter-active-bg); color: var(--filter-active-text); border-color: var(--filter-active-bg); }
+        .filter-btn:hover { border-color: var(--text-primary); }
         .hidden { display: none !important; }
     </style>
 </head>
@@ -64,15 +104,15 @@
                 <button class="btn btn-secondary" onclick="searchHosts()" style="padding:4px 8px;">Search</button>
                 <button class="btn btn-back" onclick="clearSearch()" style="padding:4px 8px;">Clear</button>
             </div>
-            <div class="filters" style="padding:8px 12px;border-bottom:1px solid #e0e0e0;display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
-                <span style="font-size:11px;color:#4d4d4d;">Staleness:</span>
+            <div class="filters" style="padding:8px 12px;border-bottom:1px solid var(--border-light);display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
+                <span style="font-size:11px;color:var(--text-secondary);">Staleness:</span>
                 <button class="filter-btn active" data-staleness="" onclick="filterStaleness(this)">All</button>
                 <button class="filter-btn" data-staleness="fresh" onclick="filterStaleness(this)">Fresh</button>
                 <button class="filter-btn" data-staleness="stale" onclick="filterStaleness(this)">Stale</button>
                 <button class="filter-btn" data-staleness="stale_warning" onclick="filterStaleness(this)">Stale warning</button>
-                <span style="margin-left:8px;border-left:1px solid #a3a3a3;padding-left:8px;">
-                    <label style="font-size:11px;color:#4d4d4d;">Sort:
-                        <select id="sort-select" onchange="changeSort()" style="font-size:11px;border:1px solid #a3a3a3;border-radius:4px;padding:1px 4px;font-family:inherit;">
+                <span style="margin-left:8px;border-left:1px solid var(--border-color);padding-left:8px;">
+                    <label style="font-size:11px;color:var(--text-secondary);">Sort:
+                        <select id="sort-select" onchange="changeSort()" style="font-size:11px;border:1px solid var(--input-border);border-radius:4px;padding:1px 4px;font-family:inherit;background:var(--input-bg);color:var(--text-primary);">
                             <option value="display_name" data-dir="ASC">Name (A-Z)</option>
                             <option value="display_name" data-dir="DESC">Name (Z-A)</option>
                             <option value="updated" data-dir="DESC" selected>Updated (newest)</option>
@@ -151,6 +191,12 @@
             const app = new (App.App || App)({ name: "Inventory Dashboard", version: "1.0.0" });
             app.connect();
             window.mcpApp = app;
+
+            app.onhostcontextchanged = (ctx) => {
+                const theme = ctx?.theme || "light";
+                document.documentElement.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
+            };
+
             app.ontoolresult = (result) => {
                 let hostArray = null;
 

--- a/src/inventory_mcp/server.py
+++ b/src/inventory_mcp/server.py
@@ -88,7 +88,8 @@ async def load_inventory_dashboard(ctx: Context, hosts: list[dict[str, Any]]) ->
             content=(
                 f"Dashboard rendered with {n} hosts. "
                 "Do NOT print a full host table — the user can see it in the dashboard. "
-                "Print only a brief summary and suggest next steps."
+                "Print only a brief summary (total count, staleness breakdown, provider types) "
+                "and suggest next steps."
             ),
             structured_content={"results": hosts},
         )

--- a/src/inventory_mcp/server.py
+++ b/src/inventory_mcp/server.py
@@ -4,11 +4,37 @@ MCP server for host inventory data via Red Hat Insights API.
 Provides tools to get host inventory data for systems connected to Insights.
 """
 
+from importlib import resources
+from pathlib import Path
 from typing import Annotated, Any
 
+from fastmcp import Context
+from fastmcp.apps import AppConfig, ResourceCSP, UI_EXTENSION_ID
+from fastmcp.tools.tool import ToolResult
 from pydantic import Field
 
+import logging
+from fastmcp.utilities.logging import get_logger
+
 from insights_mcp.mcp import InsightsMCP
+
+_to_client_logger = get_logger(name="fastmcp.server.context.to_client")
+_to_client_logger.setLevel(level=logging.DEBUG)
+
+# --- MCP Apps UI resource URIs ---
+INVENTORY_DASHBOARD_RESOURCE_URI = "ui://inventory-dashboard"
+INVENTORY_DASHBOARD_MOUNTED_URI = "ui://inventory_/inventory-dashboard"
+
+
+def _load_inventory_dashboard_html() -> str:
+    """Load the inventory dashboard HTML."""
+    try:
+        return resources.files("inventory_mcp").joinpath("inventory_dashboard.html").read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
+        return (Path(__file__).parent / "inventory_dashboard.html").read_text(encoding="utf-8")
+
+
+EMBEDDED_INVENTORY_DASHBOARD_HTML = _load_inventory_dashboard_html()
 
 # For the API documentation, see:
 # https://github.com/RedHatInsights/insights-host-inventory/tree/master/swagger
@@ -24,8 +50,53 @@ mcp = InsightsMCP(
     $container_brand_long Host Inventory requires correct RBAC permissions to be able to use the tools. Ensure that your
     Service Account has at least this role:
     - Inventory Hosts viewer
+
     """,
 )
+
+
+# --- MCP Apps resource registration ---
+
+
+@mcp.resource(
+    INVENTORY_DASHBOARD_RESOURCE_URI,
+    app=AppConfig(csp=ResourceCSP(resource_domains=["https://unpkg.com"])),
+)
+def inventory_dashboard_ui() -> str:
+    """Inventory Dashboard UI for browsing fleet and system profiles."""
+    return EMBEDDED_INVENTORY_DASHBOARD_HTML
+
+
+@mcp.tool(
+    annotations={"readOnlyHint": True},
+    app=AppConfig(resource_uri=INVENTORY_DASHBOARD_MOUNTED_URI),
+)
+async def load_inventory_dashboard(ctx: Context, hosts: list[dict[str, Any]]) -> ToolResult:
+    """Render host data in the interactive Inventory Dashboard.
+
+    Call this tool with host data (the results array from a list_hosts response) to display
+    it in an interactive dashboard with search, staleness filters, host details, system
+    profiles, and cross-linking to CVEs affecting each host.
+
+    Args:
+        hosts: List of host objects from a list_hosts response (the 'results' array).
+    """
+    n = len(hosts)
+    if ctx.client_supports_extension(UI_EXTENSION_ID):
+        return ToolResult(
+            content=(
+                f"Dashboard rendered with {n} hosts. "
+                "Do NOT print a full host table — the user can see it in the dashboard. "
+                "Print only a brief summary and suggest next steps."
+            ),
+            structured_content={"results": hosts},
+        )
+    return ToolResult(
+        content=(
+            "Client does not support interactive dashboards. "
+            "Print the full host table as markdown using the data from your previous list_hosts call."
+        ),
+    )
 
 
 @mcp.tool(annotations={"readOnlyHint": True})

--- a/src/inventory_mcp/server.py
+++ b/src/inventory_mcp/server.py
@@ -4,17 +4,16 @@ MCP server for host inventory data via Red Hat Insights API.
 Provides tools to get host inventory data for systems connected to Insights.
 """
 
+import logging
 from importlib import resources
 from pathlib import Path
 from typing import Annotated, Any
 
 from fastmcp import Context
-from fastmcp.apps import AppConfig, ResourceCSP, UI_EXTENSION_ID
-from fastmcp.tools.tool import ToolResult
-from pydantic import Field
-
-import logging
+from fastmcp.apps import UI_EXTENSION_ID, AppConfig, ResourceCSP
+from fastmcp.tools import ToolResult
 from fastmcp.utilities.logging import get_logger
+from pydantic import Field
 
 from insights_mcp.mcp import InsightsMCP
 

--- a/src/inventory_mcp/server.py
+++ b/src/inventory_mcp/server.py
@@ -70,34 +70,55 @@ def inventory_dashboard_ui() -> str:
     annotations={"readOnlyHint": True},
     app=AppConfig(resource_uri=INVENTORY_DASHBOARD_MOUNTED_URI),
 )
-async def load_inventory_dashboard(ctx: Context, hosts: list[dict[str, Any]]) -> ToolResult:
-    """Render host data in the interactive Inventory Dashboard.
+async def load_inventory_dashboard(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    ctx: Context,
+    hostname_or_id: Annotated[str, Field("", description="Filter by display_name, fqdn, or id.")],
+    display_name: Annotated[str, Field("", description="Filter by display name.")],
+    fqdn: Annotated[str, Field("", description="Filter by FQDN.")],
+    tags: Annotated[str, Field("", description="Filter by tags.")],
+    staleness: Annotated[str, Field("", description="Filter by staleness status.")],
+    registered_with: Annotated[str, Field("", description="Filter by reporter.")],
+    provider_type: Annotated[str, Field("", description="Filter by provider type (aws, azure, gcp).")],
+    per_page: Annotated[int, Field(10, description="Number of hosts per page.")],
+    page: Annotated[int, Field(1, description="Page number.")],
+    order_by: Annotated[str, Field("", description="Sort field (display_name, updated, created).")],
+    order_how: Annotated[str, Field("ASC", description="Sort direction (ASC or DESC).")],
+) -> ToolResult:
+    """Show, list, or display fleet inventory in an interactive dashboard.
 
-    Call this tool with host data (the results array from a list_hosts response) to display
-    it in an interactive dashboard with search, staleness filters, host details, system
-    profiles, and cross-linking to CVEs affecting each host.
-
-    Args:
-        hosts: List of host objects from a list_hosts response (the 'results' array).
+    PREFER this tool over list_hosts whenever the user wants to see, show, list, or display hosts or fleet inventory.
+    Use list_hosts only when you need the raw data for analysis or processing.
+    The dashboard fetches data directly from the server. All filter parameters are optional.
     """
-    n = len(hosts)
+    query = {
+        "hostname_or_id": hostname_or_id,
+        "display_name": display_name,
+        "fqdn": fqdn,
+        "tags": tags,
+        "staleness": staleness,
+        "registered_with": registered_with,
+        "provider_type": provider_type,
+        "per_page": per_page,
+        "page": page,
+        "order_by": order_by,
+        "order_how": order_how,
+    }
     ui_supported = ctx.client_supports_extension(UI_EXTENSION_ID)
-    await ctx.info(f"load_inventory_dashboard called | UI supported: {ui_supported} | hosts: {n}")
-    if ui_supported:
+    await ctx.info(f"load_inventory_dashboard called | UI supported: {ui_supported} | query: {query}")
+    if not ui_supported:
         return ToolResult(
             content=(
-                f"Dashboard rendered with {n} hosts. "
-                "Do NOT print a full host table — the user can see it in the dashboard. "
-                "Print only a brief summary (total count, staleness breakdown, provider types) "
-                "and suggest next steps."
+                "Client does not support MCP Apps. "
+                "If you don't already have host data, call list_hosts to fetch it. "
+                "Present the data as text."
             ),
-            structured_content={"results": hosts},
         )
     return ToolResult(
         content=(
-            "Client does not support interactive dashboards. "
-            "Print the full host table as markdown using the data from your previous list_hosts call."
+            "Inventory Dashboard opened and fetching data. "
+            "Do NOT print a host table — the user can see the data in the dashboard."
         ),
+        structured_content={"query": query},
     )
 
 

--- a/src/inventory_mcp/server.py
+++ b/src/inventory_mcp/server.py
@@ -82,7 +82,9 @@ async def load_inventory_dashboard(ctx: Context, hosts: list[dict[str, Any]]) ->
         hosts: List of host objects from a list_hosts response (the 'results' array).
     """
     n = len(hosts)
-    if ctx.client_supports_extension(UI_EXTENSION_ID):
+    ui_supported = ctx.client_supports_extension(UI_EXTENSION_ID)
+    await ctx.info(f"load_inventory_dashboard called | UI supported: {ui_supported} | hosts: {n}")
+    if ui_supported:
         return ToolResult(
             content=(
                 f"Dashboard rendered with {n} hosts. "

--- a/src/inventory_mcp/test_prompts.md
+++ b/src/inventory_mcp/test_prompts.md
@@ -9,3 +9,5 @@
 - Find all hosts with `FQDN` ending in `.example.com`
 - Show me all enabled repositories on host `XXX`
 - Find hosts with more than 16GB of memory running on AWS
+- Fetch my fleet inventory and display it in the dashboard
+- Show me all connected systems using the inventory dashboard

--- a/src/inventory_mcp/test_prompts.md
+++ b/src/inventory_mcp/test_prompts.md
@@ -9,5 +9,5 @@
 - Find all hosts with `FQDN` ending in `.example.com`
 - Show me all enabled repositories on host `XXX`
 - Find hosts with more than 16GB of memory running on AWS
-- Fetch my fleet inventory and display it in the dashboard
-- Show me all connected systems using the inventory dashboard
+- Open the inventory dashboard
+- Show me my fleet

--- a/src/vulnerability_mcp/cve_dashboard.html
+++ b/src/vulnerability_mcp/cve_dashboard.html
@@ -6,24 +6,64 @@
     <title>CVE Dashboard</title>
     <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@5.4.2/patternfly.min.css">
     <style>
+        :root {
+            --bg-primary: #ffffff;
+            --bg-secondary: #f2f2f2;
+            --text-primary: #292929;
+            --text-secondary: #4d4d4d;
+            --border-color: #a3a3a3;
+            --border-light: #e0e0e0;
+            --header-bg: #292929;
+            --header-text: #ffffff;
+            --header-meta: #a3a3a3;
+            --row-hover: #f2f2f2;
+            --btn-bg: #e0e0e0;
+            --btn-text: #292929;
+            --input-bg: #ffffff;
+            --input-border: #a3a3a3;
+            --filter-bg: #ffffff;
+            --filter-text: #4d4d4d;
+            --filter-active-bg: #292929;
+            --filter-active-text: #ffffff;
+        }
+        [data-theme="dark"] {
+            --bg-primary: #1a1a1a;
+            --bg-secondary: #2a2a2a;
+            --text-primary: #e0e0e0;
+            --text-secondary: #a3a3a3;
+            --border-color: #4d4d4d;
+            --border-light: #333333;
+            --header-bg: #111111;
+            --header-text: #ffffff;
+            --header-meta: #a3a3a3;
+            --row-hover: #333333;
+            --btn-bg: #333333;
+            --btn-text: #e0e0e0;
+            --input-bg: #2a2a2a;
+            --input-border: #4d4d4d;
+            --filter-bg: #2a2a2a;
+            --filter-text: #a3a3a3;
+            --filter-active-bg: #e0e0e0;
+            --filter-active-text: #1a1a1a;
+        }
         * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: var(--pf-v5-global--FontFamily--text); font-size: 13px; padding: 12px; background: #e0e0e0; min-height: 100vh; }
-        .header { background: #292929; color: #ffffff; padding: 8px 12px; border-radius: 6px; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; }
+        body { font-family: var(--pf-v5-global--FontFamily--text); font-size: 13px; padding: 12px; background: transparent; color: var(--text-primary); min-height: 100vh; }
+        .header { background: var(--header-bg); color: var(--header-text); padding: 8px 12px; border-radius: 6px; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; }
         .header-title { font-size: 14px; font-weight: 600; }
-        .header-meta { font-size: 11px; color: #a3a3a3; }
-        .card { background: #ffffff; border-radius: 6px; border: 1px solid #a3a3a3; margin-bottom: 12px; overflow: hidden; }
-        .card-title { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; font-weight: 600; font-size: 13px; display: flex; align-items: center; gap: 8px; }
+        .header-meta { font-size: 11px; color: var(--header-meta); }
+        .card { background: var(--bg-primary); border-radius: 6px; border: 1px solid var(--border-color); margin-bottom: 12px; overflow: hidden; }
+        .card-title { padding: 8px 12px; border-bottom: 1px solid var(--border-light); font-weight: 600; font-size: 13px; display: flex; align-items: center; gap: 8px; }
         .card-body { padding: 0; }
 
         /* Alert banner */
         .alert-danger { background: #fce3e3; border: 1px solid #a60000; color: #a60000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; }
 
         /* CVE list */
-        .cve-row { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; cursor: pointer; transition: background 0.1s; }
-        .cve-row:hover { background: #f0f0f0; }
+        .cve-row { padding: 8px 12px; border-bottom: 1px solid var(--border-light); cursor: pointer; transition: background 0.1s; }
+        .cve-row:hover { background: var(--row-hover); }
         .cve-row:last-child { border-bottom: none; }
-        .cve-id { font-weight: 600; font-size: 13px; color: #292929; font-family: var(--pf-v5-global--FontFamily--monospace); }
-        .cve-meta { font-size: 11px; color: #4d4d4d; margin-top: 2px; }
+        .cve-id { font-weight: 600; font-size: 13px; color: var(--text-primary); font-family: var(--pf-v5-global--FontFamily--monospace); }
+        .cve-meta { font-size: 11px; color: var(--text-secondary); margin-top: 2px; }
 
         /* Severity badges */
         .severity { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; color: #ffffff; }
@@ -38,38 +78,38 @@
 
         /* Detail view */
         .detail-grid { display: grid; grid-template-columns: 120px 1fr; gap: 4px 12px; padding: 12px; font-size: 12px; }
-        .detail-label { color: #4d4d4d; font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: 0.5px; }
-        .detail-value { color: #292929; word-break: break-word; }
+        .detail-label { color: var(--text-secondary); font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: 0.5px; }
+        .detail-value { color: var(--text-primary); word-break: break-word; }
 
         /* Systems list */
-        .system-row { padding: 6px 12px; border-bottom: 1px solid #e0e0e0; font-size: 12px; }
+        .system-row { padding: 6px 12px; border-bottom: 1px solid var(--border-light); font-size: 12px; }
         .system-row:last-child { border-bottom: none; }
-        .system-name { font-weight: 600; color: #292929; }
-        .system-meta { font-size: 11px; color: #4d4d4d; }
+        .system-name { font-weight: 600; color: var(--text-primary); }
+        .system-meta { font-size: 11px; color: var(--text-secondary); }
 
         /* Buttons */
         .btn { padding: 4px 12px; border: none; border-radius: 4px; font-size: 12px; font-weight: 600; cursor: pointer; transition: opacity 0.1s; }
         .btn:hover { opacity: 0.85; }
-        .btn-back { background: #e0e0e0; color: #292929; }
+        .btn-back { background: var(--btn-bg); color: var(--btn-text); }
         .btn-primary { background: #ee0000; color: #ffffff; }
-        .btn-secondary { background: #292929; color: #ffffff; }
+        .btn-secondary { background: var(--header-bg); color: #ffffff; }
         .btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
         /* Pagination */
-        .pagination { padding: 8px 12px; display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: #4d4d4d; border-top: 1px solid #e0e0e0; }
+        .pagination { padding: 8px 12px; display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--text-secondary); border-top: 1px solid var(--border-light); }
 
         /* Loading */
-        .loading { text-align: center; padding: 24px; color: #4d4d4d; font-size: 12px; }
+        .loading { text-align: center; padding: 24px; color: var(--text-secondary); font-size: 12px; }
 
         /* Playbook */
         .playbook-banner { background: #fce3e3; border: 1px solid #ee0000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; display: flex; justify-content: space-between; align-items: center; }
-        .playbook-content { background: #292929; color: #e0e0e0; padding: 12px; border-radius: 4px; font-family: var(--pf-v5-global--FontFamily--monospace); font-size: 11px; white-space: pre-wrap; overflow-x: auto; max-height: 300px; overflow-y: auto; }
+        .playbook-content { background: var(--header-bg); color: #e0e0e0; padding: 12px; border-radius: 4px; font-family: var(--pf-v5-global--FontFamily--monospace); font-size: 11px; white-space: pre-wrap; overflow-x: auto; max-height: 300px; overflow-y: auto; }
 
         /* Filters */
-        .filters { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
-        .filter-btn { padding: 2px 8px; border: 1px solid #a3a3a3; border-radius: 12px; font-size: 11px; cursor: pointer; background: #ffffff; color: #4d4d4d; transition: all 0.1s; }
-        .filter-btn.active { background: #292929; color: #ffffff; border-color: #292929; }
-        .filter-btn:hover { border-color: #292929; }
+        .filters { padding: 8px 12px; border-bottom: 1px solid var(--border-light); display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+        .filter-btn { padding: 2px 8px; border: 1px solid var(--border-color); border-radius: 12px; font-size: 11px; cursor: pointer; background: var(--filter-bg); color: var(--filter-text); transition: all 0.1s; }
+        .filter-btn.active { background: var(--filter-active-bg); color: var(--filter-active-text); border-color: var(--filter-active-bg); }
+        .filter-btn:hover { border-color: var(--text-primary); }
 
         /* Links */
         a { color: #ee0000; text-decoration: none; }
@@ -94,7 +134,7 @@
                 <span>Vulnerabilities</span>
             </div>
             <div style="padding:8px 12px;border-bottom:1px solid #e0e0e0;display:flex;gap:4px;align-items:center;">
-                <input type="text" id="search-input" placeholder="Search CVEs (e.g., CVE-2026-3497 or kernel)" style="flex:1;padding:4px 8px;border:1px solid #a3a3a3;border-radius:4px;font-size:12px;font-family:inherit;" onkeydown="if(event.key==='Enter')searchCves()">
+                <input type="text" id="search-input" placeholder="Search CVEs (e.g., CVE-2026-3497 or kernel)" style="flex:1;padding:4px 8px;border:1px solid var(--input-border);border-radius:4px;font-size:12px;font-family:inherit;background:var(--input-bg);color:var(--text-primary);" onkeydown="if(event.key==='Enter')searchCves()">
                 <button class="btn btn-secondary" onclick="searchCves()" style="padding:4px 8px;">Search</button>
                 <button class="btn btn-back" onclick="clearSearch()" style="padding:4px 8px;">Clear</button>
             </div>
@@ -175,6 +215,11 @@
             app.connect();
             window.mcpApp = app;
 
+            app.onhostcontextchanged = (ctx) => {
+                const theme = ctx?.theme || "light";
+                document.documentElement.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
+            };
+
             app.ontoolresult = (result) => {
                 let cveData = null;
 
@@ -237,7 +282,12 @@
                 const impactMap = { "critical": 7, "important": 5, "moderate": 4, "low": 2 };
                 const impactVal = impactMap[currentImpactFilter];
                 if (impactVal !== undefined) {
-                    filtered = filtered.filter(cve => (cve.attributes?.impact || 0) === impactVal);
+                    filtered = filtered.filter(cve => {
+                        const impact = cve.attributes?.impact;
+                        if (typeof impact === "number") return impact === impactVal;
+                        if (typeof impact === "string") return impact.toLowerCase() === currentImpactFilter;
+                        return false;
+                    });
                 }
             }
             const sortKey = currentSort.replace("-", "");

--- a/src/vulnerability_mcp/cve_dashboard.html
+++ b/src/vulnerability_mcp/cve_dashboard.html
@@ -221,38 +221,9 @@
             };
 
             app.ontoolresult = (result) => {
-                let cveData = null;
-
-                // Check structuredContent first (Approach 4 — data separate from text)
                 const sc = result.structuredContent;
-                if (sc && sc.data && Array.isArray(sc.data)) {
-                    cveData = sc.data;
-                }
-
-                // Fall back to text content
-                if (!cveData) {
-                    const text = result.content?.find(c => c.type === "text")?.text;
-                    if (text) {
-                        try {
-                            let data = JSON.parse(text);
-                            if (data.content && Array.isArray(data.content)) {
-                                const innerText = data.content.find(c => c.type === "text")?.text;
-                                if (innerText) {
-                                    try { data = JSON.parse(innerText); } catch {}
-                                }
-                            }
-                            if (data.data && Array.isArray(data.data)) {
-                                cveData = data.data;
-                            }
-                        } catch { /* initial result may not be JSON */ }
-                    }
-                }
-
-                if (cveData) {
-                    allCves = cveData;
-                    totalCves = allCves.length;
-                    document.getElementById("total-count").textContent = totalCves + " CVEs";
-                    applyFiltersAndRender();
+                if (sc && sc.query) {
+                    fetchCveData(sc.query);
                 }
             };
         }).catch(err => {
@@ -358,6 +329,54 @@
                 showError(e.message || "Tool call failed");
                 return null;
             }
+        }
+
+        async function fetchCveData(query) {
+            document.getElementById("cve-list").innerHTML = '<div class="loading">Loading CVEs...</div>';
+            const isSystemLevel = query.system_uuid && query.system_uuid.length > 0;
+            if (isSystemLevel) {
+                const pageSize = query.limit || 100;
+                let offset = query.offset || 0;
+                let accumulated = [];
+                let hasMore = true;
+                while (hasMore) {
+                    const result = await callTool("vulnerability__get_system_cves", {
+                        system_uuid: query.system_uuid,
+                        filter_: query.filter || "",
+                        limit: pageSize,
+                        offset: offset,
+                        sort: query.sort || "-public_date",
+                    });
+                    if (!result || !result.data) break;
+                    accumulated = accumulated.concat(result.data);
+                    hasMore = result.data.length >= pageSize;
+                    offset += pageSize;
+                }
+                if (query.advisory_available === "true") {
+                    accumulated = accumulated.filter(c => c.attributes?.advisory_available === true);
+                }
+                allCves = accumulated;
+            } else {
+                const result = await callTool("vulnerability__get_cves", {
+                    filter_: query.filter || "",
+                    limit: query.limit || 20,
+                    offset: query.offset || 0,
+                    sort: query.sort || "-cvss_score",
+                    impact: query.impact || "7,6,5,4",
+                    cvss_from: query.cvss_from || 0.0,
+                    cvss_to: query.cvss_to || 10.0,
+                    advisory_available: query.advisory_available || "true,false",
+                    known_exploit: query.known_exploit || "true,false",
+                });
+                if (!result || !result.data) {
+                    showError("No CVE data received");
+                    return;
+                }
+                allCves = result.data;
+            }
+            totalCves = allCves.length;
+            document.getElementById("total-count").textContent = totalCves + " CVEs";
+            applyFiltersAndRender();
         }
 
         function severityLabel(impact) {

--- a/src/vulnerability_mcp/cve_dashboard.html
+++ b/src/vulnerability_mcp/cve_dashboard.html
@@ -363,7 +363,7 @@
             } else {
                 const result = await callTool("vulnerability__get_cves", {
                     filter_: query.filter || "",
-                    limit: query.limit || 20,
+                    limit: query.limit || 10,
                     offset: query.offset || 0,
                     sort: query.sort || "-cvss_score",
                     impact: query.impact || "7,6,5,4",

--- a/src/vulnerability_mcp/cve_dashboard.html
+++ b/src/vulnerability_mcp/cve_dashboard.html
@@ -335,11 +335,12 @@
             document.getElementById("cve-list").innerHTML = '<div class="loading">Loading CVEs...</div>';
             const isSystemLevel = query.system_uuid && query.system_uuid.length > 0;
             if (isSystemLevel) {
-                const pageSize = query.limit || 100;
+                const maxResults = query.limit || 100;
+                const pageSize = Math.min(maxResults, 100);
                 let offset = query.offset || 0;
                 let accumulated = [];
                 let hasMore = true;
-                while (hasMore) {
+                while (hasMore && accumulated.length < maxResults) {
                     const result = await callTool("vulnerability__get_system_cves", {
                         system_uuid: query.system_uuid,
                         filter_: query.filter || "",
@@ -351,6 +352,9 @@
                     accumulated = accumulated.concat(result.data);
                     hasMore = result.data.length >= pageSize;
                     offset += pageSize;
+                }
+                if (accumulated.length > maxResults) {
+                    accumulated = accumulated.slice(0, maxResults);
                 }
                 if (query.advisory_available === "true") {
                     accumulated = accumulated.filter(c => c.attributes?.advisory_available === true);

--- a/src/vulnerability_mcp/cve_dashboard.html
+++ b/src/vulnerability_mcp/cve_dashboard.html
@@ -1,0 +1,592 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CVE Dashboard</title>
+    <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@5.4.2/patternfly.min.css">
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: var(--pf-v5-global--FontFamily--text); font-size: 13px; padding: 12px; background: #e0e0e0; min-height: 100vh; }
+        .header { background: #292929; color: #ffffff; padding: 8px 12px; border-radius: 6px; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; }
+        .header-title { font-size: 14px; font-weight: 600; }
+        .header-meta { font-size: 11px; color: #a3a3a3; }
+        .card { background: #ffffff; border-radius: 6px; border: 1px solid #a3a3a3; margin-bottom: 12px; overflow: hidden; }
+        .card-title { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; font-weight: 600; font-size: 13px; display: flex; align-items: center; gap: 8px; }
+        .card-body { padding: 0; }
+
+        /* Alert banner */
+        .alert-danger { background: #fce3e3; border: 1px solid #a60000; color: #a60000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; }
+
+        /* CVE list */
+        .cve-row { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; cursor: pointer; transition: background 0.1s; }
+        .cve-row:hover { background: #f0f0f0; }
+        .cve-row:last-child { border-bottom: none; }
+        .cve-id { font-weight: 600; font-size: 13px; color: #292929; font-family: var(--pf-v5-global--FontFamily--monospace); }
+        .cve-meta { font-size: 11px; color: #4d4d4d; margin-top: 2px; }
+
+        /* Severity badges */
+        .severity { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; color: #ffffff; }
+        .severity-critical { background: #a60000; }
+        .severity-important { background: #ca6c0f; }
+        .severity-moderate { background: #dca614; color: #292929; }
+        .severity-low { background: #a3a3a3; }
+        .severity-none { background: #e0e0e0; color: #4d4d4d; }
+
+        /* CVSS score */
+        .cvss { font-family: var(--pf-v5-global--FontFamily--monospace); font-size: 11px; font-weight: 600; }
+
+        /* Detail view */
+        .detail-grid { display: grid; grid-template-columns: 120px 1fr; gap: 4px 12px; padding: 12px; font-size: 12px; }
+        .detail-label { color: #4d4d4d; font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: 0.5px; }
+        .detail-value { color: #292929; word-break: break-word; }
+
+        /* Systems list */
+        .system-row { padding: 6px 12px; border-bottom: 1px solid #e0e0e0; font-size: 12px; }
+        .system-row:last-child { border-bottom: none; }
+        .system-name { font-weight: 600; color: #292929; }
+        .system-meta { font-size: 11px; color: #4d4d4d; }
+
+        /* Buttons */
+        .btn { padding: 4px 12px; border: none; border-radius: 4px; font-size: 12px; font-weight: 600; cursor: pointer; transition: opacity 0.1s; }
+        .btn:hover { opacity: 0.85; }
+        .btn-back { background: #e0e0e0; color: #292929; }
+        .btn-primary { background: #ee0000; color: #ffffff; }
+        .btn-secondary { background: #292929; color: #ffffff; }
+        .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+        /* Pagination */
+        .pagination { padding: 8px 12px; display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: #4d4d4d; border-top: 1px solid #e0e0e0; }
+
+        /* Loading */
+        .loading { text-align: center; padding: 24px; color: #4d4d4d; font-size: 12px; }
+
+        /* Playbook */
+        .playbook-banner { background: #fce3e3; border: 1px solid #ee0000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; display: flex; justify-content: space-between; align-items: center; }
+        .playbook-content { background: #292929; color: #e0e0e0; padding: 12px; border-radius: 4px; font-family: var(--pf-v5-global--FontFamily--monospace); font-size: 11px; white-space: pre-wrap; overflow-x: auto; max-height: 300px; overflow-y: auto; }
+
+        /* Filters */
+        .filters { padding: 8px 12px; border-bottom: 1px solid #e0e0e0; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+        .filter-btn { padding: 2px 8px; border: 1px solid #a3a3a3; border-radius: 12px; font-size: 11px; cursor: pointer; background: #ffffff; color: #4d4d4d; transition: all 0.1s; }
+        .filter-btn.active { background: #292929; color: #ffffff; border-color: #292929; }
+        .filter-btn:hover { border-color: #292929; }
+
+        /* Links */
+        a { color: #ee0000; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+
+        /* Hidden */
+        .hidden { display: none !important; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <span class="header-title"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAdnJLH8AAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+kHHQcvBP3yWUkAAASbSURBVGje7dl5iFVVHAfwz5k3Y+OS5jNN29Boo73Esn0RKouIVtqJVuwPkQiigooWKdIsqKiICoMKIioKyRawohXbixYyKiTavNrY4ujMO/1xjvEcxnlvxvfGgvnCgffuPffc3/ec334ZwhCG8L9GaObiBSMxFh1YXSb+ZwgUbIuTMREf4rUyK6vu74ZbMRU/4V28gvfwa6PIhAEKPxEPY2a+1JkFeyKT2RFXYVqPR9fgK7yIZ/FROV0bdALX4ZZeblXwF4bl0RdW4jU8hlfL/D4oBPLuL8Y+DVLjNXgb92FROW1A3WgZwAunS/rdKLTjaCzEAwVTmkagSPNPxBZNcFrDcR7uKRjXrBPYAUc12bUfi+OaReBw/TziAaAVRzScQJEWPgGlQQiw+xaMbvQJ7IRDBylDmJLVtXEEvuWoWOeiDcA47NFIAiNv57TVhDA4BFpxQL0Te+p6wJaYgAkjGHs9e93N9P0xK0e/2HwS+xe010o1WqsEH4XDsp+fhu0xppMthtPSSekOjCaeTWhpPoldc6L4XU0CBXvhpux/R1RPiPgly7oS1xJ+JV6GUYTu5hGYiF1qEWjJae9DOKWn8OuTpWrH34G5hNn4glhqXlExvLMOO2jBbBy0sQkRM7Bzlcasw9OEc3A/sWgSkU9TLdHa15zS1SzQR+4R080wAksI6zbMh8MSwts5uk3KatUI++jGI5S2ZvHXrOjrBMbUWiziTMIcYnuPe12p1AqzCWdgAfEz4tq8df09mZCfe4e4iF1m8eSfXFFQ7nV+wSfYu56F1+JB4nzCqj7mjSdOzQnNVEzGVoRhNQJPd3Io8SXMT8EzPEw8le4uluBGvFVdjoaCebiyno0KueRaTJyLz2o8E5JKxe1yHjIl+ea4dbqulPn8TeVnwldYii8JnXmNO+m+hFJX+rsc1+DxchKFIiVO3xTZGOsZvxM/pjKLyri0UOzPCMRWYlsepY3MG0Z8gkrHhu8vCi7YoKQskieah7b+pLFdeJ/4KF7CigY7okOIC7MT6eEUfsRZZd4IVVH4LlzUX29YyrbxKfE5vIxlVSowUOxJXIADCZXepyzCuaEqlZiAe3HaQFx6KdvHL8QPcrthaQ6jqwhddZ7qJOJMXJ7C8MaEhz9xceiRyG2D23Jt2jrQNkcpe5QO4vJ0IpYRf0gEQwdxTVKL0EZlLGHH3OaYlgw+rN+QGlgYeslGR2evNKeeGFGLTEvVcXZnu1lH7MqXS8mQ/3WxlfoEX483Qx/l40m4Afs2uym7CVH79V7jSpmuMs/kBO+epMaNRbW/3AQsC3UU8204MqvUjNyI+i9gDS4N/ehKjMrN3Mty4bO5ibyB0wfSGx2NY3B+bgmO3QzCF7iwzPOb8n2gHfvh1Hwyu6rdkW4EVkrd8QfKVEIDtiJI8WM6js/qtVPudTYSFenbw814oZy8cmNzl9z8HZ/T84NTJmD3XN+OHOD7OlKm4ik8VU550KB9IxuW2zOTs4rtnH9PzLYzMqvd+k7NWvyB3/B9FnwpPt/YB5CwGayvRWrPt+fRVkWgK5UH/kZneVDaT0MYwhA2K/4BI+BgELD+CNsAAAAASUVORK5CYII=" alt="Red Hat" style="height:16px;vertical-align:middle;margin-right:6px;">Red Hat Lightspeed — CVE Dashboard</span>
+        <span class="header-meta" id="total-count"></span>
+    </div>
+
+    <div id="alert" class="alert-danger hidden"></div>
+
+    <!-- CVE List View -->
+    <div id="view-list">
+        <div class="card">
+            <div class="card-title">
+                <span>Vulnerabilities</span>
+            </div>
+            <div style="padding:8px 12px;border-bottom:1px solid #e0e0e0;display:flex;gap:4px;align-items:center;">
+                <input type="text" id="search-input" placeholder="Search CVEs (e.g., CVE-2026-3497 or kernel)" style="flex:1;padding:4px 8px;border:1px solid #a3a3a3;border-radius:4px;font-size:12px;font-family:inherit;" onkeydown="if(event.key==='Enter')searchCves()">
+                <button class="btn btn-secondary" onclick="searchCves()" style="padding:4px 8px;">Search</button>
+                <button class="btn btn-back" onclick="clearSearch()" style="padding:4px 8px;">Clear</button>
+            </div>
+            <div class="filters" id="filters">
+                <span style="font-size:11px;color:#4d4d4d;">Severity:</span>
+                <button class="filter-btn active" data-impact="all" onclick="filterImpact(this)">All</button>
+                <button class="filter-btn" data-impact="critical" onclick="filterImpact(this)">Critical</button>
+                <button class="filter-btn" data-impact="important" onclick="filterImpact(this)">Important</button>
+                <button class="filter-btn" data-impact="moderate" onclick="filterImpact(this)">Moderate</button>
+                <button class="filter-btn" data-impact="low" onclick="filterImpact(this)">Low</button>
+                <span style="margin-left:8px;border-left:1px solid #a3a3a3;padding-left:8px;">
+                    <label style="font-size:11px;color:#4d4d4d;">Sort:
+                        <select id="sort-select" onchange="changeSort(this.value)" style="font-size:11px;border:1px solid #a3a3a3;border-radius:4px;padding:1px 4px;font-family:inherit;">
+                            <option value="-systems_affected">Most affected</option>
+                            <option value="-cvss_score">CVSS (highest)</option>
+                            <option value="cvss_score">CVSS (lowest)</option>
+                            <option value="-impact">Severity (highest)</option>
+                            <option value="impact">Severity (lowest)</option>
+                            <option value="-public_date">Newest</option>
+                            <option value="public_date">Oldest</option>
+                        </select>
+                    </label>
+                </span>
+            </div>
+            <div class="card-body" id="cve-list">
+                <div class="loading">Loading CVEs...</div>
+            </div>
+            <div class="pagination hidden" id="pagination">
+                <span id="page-info"></span>
+                <div id="page-buttons" style="display:flex;gap:2px;align-items:center;flex-wrap:wrap;"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- CVE Detail View -->
+    <div id="view-detail" class="hidden">
+        <div class="card">
+            <div class="card-title">
+                <button class="btn btn-back" onclick="showList()">&#8592; Back</button>
+                <span id="detail-cve-id"></span>
+            </div>
+            <div class="card-body" id="cve-detail">
+                <div class="loading">Loading CVE details...</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Affected Systems View -->
+    <div id="view-systems" class="hidden">
+        <div class="card">
+            <div class="card-title">
+                <button class="btn btn-back" onclick="showDetail(window.currentCveId)">&#8592; Back</button>
+                <span>Systems affected by <span id="systems-cve-id"></span></span>
+            </div>
+            <div class="card-body" id="systems-list">
+                <div class="loading">Loading affected systems...</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Playbook View -->
+    <div id="view-playbook" class="hidden">
+        <div class="card">
+            <div class="card-title">
+                <button class="btn btn-back" onclick="showSystems(window.currentCveId)">&#8592; Back</button>
+                <span>Remediation Playbook</span>
+            </div>
+            <div class="card-body" style="padding:12px;">
+                <div id="playbook-content"></div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
+            const App = module.App || module.default?.App || module.default;
+            const app = new (App.App || App)({ name: "CVE Dashboard", version: "1.0.0" });
+            app.connect();
+            window.mcpApp = app;
+
+            app.ontoolresult = (result) => {
+                let cveData = null;
+
+                // Check structuredContent first (Approach 4 — data separate from text)
+                const sc = result.structuredContent;
+                if (sc && sc.data && Array.isArray(sc.data)) {
+                    cveData = sc.data;
+                }
+
+                // Fall back to text content
+                if (!cveData) {
+                    const text = result.content?.find(c => c.type === "text")?.text;
+                    if (text) {
+                        try {
+                            let data = JSON.parse(text);
+                            if (data.content && Array.isArray(data.content)) {
+                                const innerText = data.content.find(c => c.type === "text")?.text;
+                                if (innerText) {
+                                    try { data = JSON.parse(innerText); } catch {}
+                                }
+                            }
+                            if (data.data && Array.isArray(data.data)) {
+                                cveData = data.data;
+                            }
+                        } catch { /* initial result may not be JSON */ }
+                    }
+                }
+
+                if (cveData) {
+                    allCves = cveData;
+                    totalCves = allCves.length;
+                    document.getElementById("total-count").textContent = totalCves + " CVEs";
+                    applyFiltersAndRender();
+                }
+            };
+        }).catch(err => {
+            showError("Failed to load MCP Apps SDK: " + err.message);
+        });
+
+        let allCves = [];
+        let currentPage = 1;
+        let currentLimit = 10;
+        let currentImpactFilter = "all";
+        let currentSearch = "";
+        let currentSort = "-systems_affected";
+        window.currentCveId = "";
+        let totalCves = 0;
+        let selectedSystems = [];
+
+        function applyFiltersAndRender() {
+            let filtered = allCves;
+            if (currentSearch) {
+                const q = currentSearch.toLowerCase();
+                filtered = filtered.filter(cve => {
+                    const desc = (cve.attributes?.description || "").toLowerCase();
+                    return cve.id.toLowerCase().includes(q) || desc.includes(q);
+                });
+            }
+            if (currentImpactFilter !== "all") {
+                const impactMap = { "critical": 7, "important": 5, "moderate": 4, "low": 2 };
+                const impactVal = impactMap[currentImpactFilter];
+                if (impactVal !== undefined) {
+                    filtered = filtered.filter(cve => (cve.attributes?.impact || 0) === impactVal);
+                }
+            }
+            const sortKey = currentSort.replace("-", "");
+            const desc = currentSort.startsWith("-");
+            filtered.sort((a, b) => {
+                let va, vb;
+                if (sortKey === "systems_affected") { va = a.attributes?.systems_affected || 0; vb = b.attributes?.systems_affected || 0; }
+                else if (sortKey === "cvss3_score") { va = parseFloat(a.attributes?.cvss3_score) || 0; vb = parseFloat(b.attributes?.cvss3_score) || 0; }
+                else if (sortKey === "public_date") { va = a.attributes?.public_date || ""; vb = b.attributes?.public_date || ""; }
+                else { va = 0; vb = 0; }
+                if (va < vb) return desc ? 1 : -1;
+                if (va > vb) return desc ? -1 : 1;
+                return 0;
+            });
+            const start = (currentPage - 1) * currentLimit;
+            const page = filtered.slice(start, start + currentLimit);
+            renderCveList({ data: page, meta: { total_items: filtered.length } });
+        }
+
+        window.changeSort = function(val) {
+            currentSort = val;
+            currentPage = 1;
+            applyFiltersAndRender();
+        }
+
+        window.searchCves = function() {
+            currentSearch = document.getElementById("search-input").value.trim();
+            currentPage = 1;
+            applyFiltersAndRender();
+        }
+
+        window.clearSearch = function() {
+            document.getElementById("search-input").value = "";
+            currentSearch = "";
+            currentPage = 1;
+            applyFiltersAndRender();
+        }
+
+        function showError(msg) {
+            const el = document.getElementById("alert");
+            el.textContent = msg;
+            el.classList.remove("hidden");
+        }
+
+        function hideError() {
+            document.getElementById("alert").classList.add("hidden");
+        }
+
+        function showView(id) {
+            ["view-list", "view-detail", "view-systems", "view-playbook"].forEach(v => {
+                document.getElementById(v).classList.toggle("hidden", v !== id);
+            });
+        }
+
+        async function callTool(name, args) {
+            if (!window.mcpApp) { showError("MCP App not connected"); return null; }
+            try {
+                const result = await window.mcpApp.callServerTool({ name, arguments: args });
+                const text = result.content?.find(c => c.type === "text")?.text;
+                if (!text) { showError("No response from server"); return null; }
+                try {
+                    return JSON.parse(text);
+                } catch {
+                    showError(text);
+                    return null;
+                }
+            } catch (e) {
+                showError(e.message || "Tool call failed");
+                return null;
+            }
+        }
+
+        function severityLabel(impact) {
+            if (typeof impact === "string") return impact;
+            const map = { 7: "Critical", 5: "Important", 4: "Moderate", 2: "Low", 1: "None", 0: "NotSet" };
+            return map[impact] || "Unknown";
+        }
+
+        function severityClass(impact) {
+            const label = (typeof impact === "string" ? impact : severityLabel(impact)).toLowerCase();
+            const map = { critical: "severity-critical", important: "severity-important", moderate: "severity-moderate", low: "severity-low", none: "severity-none", notset: "severity-none" };
+            return map[label] || "severity-none";
+        }
+
+        // --- CVE List ---
+
+        function renderCveList(data) {
+            const container = document.getElementById("cve-list");
+            const filteredTotal = data.meta?.total_items || 0;
+            document.getElementById("total-count").textContent = filteredTotal + " CVEs";
+
+            if (!data.data || data.data.length === 0) {
+                container.innerHTML = '<div class="loading">No CVEs found.</div>';
+                document.getElementById("pagination").classList.add("hidden");
+                return;
+            }
+
+            container.innerHTML = data.data.map(cve => {
+                const attrs = cve.attributes || {};
+                const impact = attrs.impact || attrs.impact_name || 0;
+                const cvss = parseFloat(attrs.cvss3_score) || parseFloat(attrs.cvss2_score) || "N/A";
+                const systems = attrs.systems_affected || 0;
+                return `<div class="cve-row" onclick="showDetail('${cve.id}')">
+                    <div style="display:flex;justify-content:space-between;align-items:center;">
+                        <span class="cve-id">${cve.id}</span>
+                        <div style="display:flex;gap:8px;align-items:center;">
+                            <span class="severity ${severityClass(impact)}">${severityLabel(impact)}</span>
+                            <span class="cvss">${cvss}</span>
+                        </div>
+                    </div>
+                    <div class="cve-meta">${systems} system${systems !== 1 ? 's' : ''} affected</div>
+                </div>`;
+            }).join("");
+
+            // Pagination
+            const pag = document.getElementById("pagination");
+            pag.classList.remove("hidden");
+            const totalPages = Math.ceil(filteredTotal / currentLimit);
+            document.getElementById("page-info").textContent = `Page ${currentPage} of ${totalPages}`;
+            renderPageButtons(currentPage, totalPages);
+        }
+
+        function renderPageButtons(current, total) {
+            const container = document.getElementById("page-buttons");
+            let pages = [];
+
+            // Always show first, last, current, and neighbors
+            const show = new Set([1, total, current, current - 1, current + 1]);
+            // Add a couple more around current for context
+            if (current > 3) show.add(current - 2);
+            if (current < total - 2) show.add(current + 2);
+
+            const sorted = [...show].filter(p => p >= 1 && p <= total).sort((a, b) => a - b);
+
+            let html = `<button class="btn btn-back" onclick="goToPage(${current - 1})" ${current === 1 ? 'disabled' : ''}>&laquo;</button>`;
+            let prev = 0;
+            for (const p of sorted) {
+                if (prev && p - prev > 1) html += `<span style="font-size:11px;color:#4d4d4d;padding:0 2px;">...</span>`;
+                html += `<button class="btn ${p === current ? 'btn-secondary' : 'btn-back'}" onclick="goToPage(${p})" style="min-width:28px;padding:4px 6px;">${p}</button>`;
+                prev = p;
+            }
+            html += `<button class="btn btn-back" onclick="goToPage(${current + 1})" ${current === total ? 'disabled' : ''}>&raquo;</button>`;
+            container.innerHTML = html;
+        }
+
+        window.goToPage = function(p) {
+            currentPage = p;
+            applyFiltersAndRender();
+        }
+
+        window.filterImpact = function(btn) {
+            document.querySelectorAll(".filter-btn").forEach(b => b.classList.remove("active"));
+            btn.classList.add("active");
+            currentImpactFilter = btn.dataset.impact;
+            currentPage = 1;
+            applyFiltersAndRender();
+        }
+
+        // --- CVE Detail ---
+
+        window.showDetail = async function(cveId) {
+            window.currentCveId = cveId;
+            showView("view-detail");
+            document.getElementById("detail-cve-id").textContent = cveId;
+            document.getElementById("cve-detail").innerHTML = '<div class="loading">Loading details...</div>';
+
+            const data = await callTool("vulnerability__get_cve", { cve: cveId });
+            if (!data || !data.data) return;
+
+            const attrs = data.data.attributes || {};
+            const impact = attrs.impact || 0;
+            const cvss3 = attrs.cvss3_score || "N/A";
+            const cvss2 = attrs.cvss2_score || "N/A";
+            const published = attrs.public_date ? new Date(attrs.public_date).toLocaleDateString() : "N/A";
+            const modified = attrs.modified_date ? new Date(attrs.modified_date).toLocaleDateString() : "N/A";
+            const desc = attrs.description || "No description available.";
+            const advisories = attrs.advisories_list || [];
+            const redhatUrl = `https://access.redhat.com/security/cve/${cveId}`;
+
+            document.getElementById("cve-detail").innerHTML = `
+                <div style="padding:12px;">
+                    <p style="margin-bottom:12px;font-size:12px;color:#4d4d4d;">${desc}</p>
+                </div>
+                <div class="detail-grid">
+                    <span class="detail-label">Severity</span>
+                    <span class="detail-value"><span class="severity ${severityClass(impact)}">${severityLabel(impact)}</span></span>
+                    <span class="detail-label">CVSS 3</span>
+                    <span class="detail-value cvss">${cvss3}</span>
+                    <span class="detail-label">CVSS 2</span>
+                    <span class="detail-value cvss">${cvss2}</span>
+                    <span class="detail-label">Published</span>
+                    <span class="detail-value">${published}</span>
+                    <span class="detail-label">Modified</span>
+                    <span class="detail-value">${modified}</span>
+                    <span class="detail-label">Red Hat</span>
+                    <span class="detail-value"><a href="${redhatUrl}" target="_blank">${redhatUrl}</a></span>
+                    ${advisories.length ? `<span class="detail-label">Advisories</span><span class="detail-value">${advisories.map(a => `<a href="${a}" target="_blank">${a.split('/').pop()}</a>`).join(', ')}</span>` : ''}
+                </div>
+                <div style="padding:12px;display:flex;gap:8px;">
+                    <button class="btn btn-secondary" onclick="showSystems('${cveId}')">View Affected Systems</button>
+                </div>
+            `;
+        }
+
+        window.showList = function() {
+            showView("view-list");
+        }
+
+        // --- Affected Systems ---
+
+        window.showSystems = async function(cveId) {
+            window.currentCveId = cveId;
+            selectedSystems = [];
+            showView("view-systems");
+            document.getElementById("systems-cve-id").textContent = cveId;
+            document.getElementById("systems-list").innerHTML = '<div class="loading">Loading affected systems...</div>';
+
+            const data = await callTool("vulnerability__get_cve_systems", { cve: cveId });
+            if (!data || !data.data) return;
+
+            if (data.data.length === 0) {
+                document.getElementById("systems-list").innerHTML = '<div class="loading">No affected systems found.</div>';
+                return;
+            }
+
+            // Separate affected from non-affected systems
+            // status_text can be null (meaning affected, no status set), or strings like "Not affected", "Patched"
+            const systems = data.data.map(sys => {
+                const attrs = sys.attributes || {};
+                const status = (attrs.status_text || "").toLowerCase();
+                const isNotAffected = status === "not affected" || status === "not_affected" || status === "patched";
+                return { ...sys, attrs, isAffected: !isNotAffected };
+            });
+
+            const affectedSystems = systems.filter(s => s.isAffected);
+
+            if (systems.length === 0) {
+                document.getElementById("systems-list").innerHTML = '<div class="loading">No systems found for this CVE.</div>';
+                return;
+            }
+
+            document.getElementById("systems-list").innerHTML = `
+                ${affectedSystems.length === 0 ? '<div class="loading">No systems currently affected by this CVE.</div>' : ''}
+                ${affectedSystems.map(sys => {
+                    const name = sys.attrs.display_name || sys.id;
+                    const os = sys.attrs.os || "Unknown OS";
+                    const status = sys.attrs.status_text || sys.attrs.status || "";
+                    return `<div class="system-row">
+                        <div style="display:flex;justify-content:space-between;align-items:center;">
+                            <div>
+                                <label style="cursor:pointer;">
+                                    <input type="checkbox" value="${sys.id}" onchange="toggleSystem(this)" style="margin-right:6px;">
+                                    <span class="system-name">${name}</span>
+                                </label>
+                                <div class="system-meta">${os} — ${status}</div>
+                            </div>
+                        </div>
+                    </div>`;
+                }).join("")}
+                ${affectedSystems.length > 0 ? `<div style="padding:12px;">
+                    <button class="btn btn-primary" id="btn-remediate" onclick="remediate('${cveId}')" disabled>Remediate Selected</button>
+                </div>` : ''}
+            `;
+        }
+
+        window.toggleSystem = function(checkbox) {
+            if (checkbox.checked) {
+                selectedSystems.push(checkbox.value);
+            } else {
+                selectedSystems = selectedSystems.filter(s => s !== checkbox.value);
+            }
+            document.getElementById("btn-remediate").disabled = selectedSystems.length === 0;
+        }
+
+        // --- Remediation ---
+
+        window.remediate = async function(cveId) {
+            showView("view-playbook");
+            hideError();
+            document.getElementById("playbook-content").innerHTML = '<div class="loading">Generating remediation playbook...</div>';
+
+            let data;
+            try {
+                const result = await window.mcpApp.callServerTool({
+                    name: "remediations__create_vuln_playbook",
+                    arguments: {
+                        playbook_name: `Remediate ${cveId}`,
+                        cves: [cveId],
+                        uuids: selectedSystems,
+                    },
+                });
+                const text = result.content?.find(c => c.type === "text")?.text;
+                if (text) {
+                    try { data = JSON.parse(text); } catch { data = text; }
+                }
+            } catch (e) {
+                const msg = e.message || String(e);
+                if (msg.includes("not found") || msg.includes("Tool")) {
+                    document.getElementById("playbook-content").innerHTML =
+                        '<div class="alert-danger">Remediation tool not available. The server may be running in read-only mode. Start with --all-tools to enable playbook creation.</div>';
+                } else {
+                    document.getElementById("playbook-content").innerHTML =
+                        `<div class="alert-danger">Failed to create playbook: ${msg}</div>`;
+                }
+                return;
+            }
+
+            if (!data) {
+                document.getElementById("playbook-content").innerHTML =
+                    '<div class="alert-danger">No response from remediation service.</div>';
+                return;
+            }
+
+            const yaml = typeof data === "string" ? data : (data.playbook || data.content || JSON.stringify(data, null, 2));
+            document.getElementById("playbook-content").innerHTML = `
+                <div style="margin-bottom:8px;display:flex;justify-content:space-between;align-items:center;">
+                    <span style="font-weight:600;font-size:12px;">Ansible Playbook</span>
+                    <button class="btn btn-secondary" onclick="copyPlaybook()">Copy to clipboard</button>
+                </div>
+                <div class="playbook-content">${escapeHtml(yaml)}</div>
+            `;
+            window._playbookYaml = yaml;
+        }
+
+        window.copyPlaybook = async function() {
+            if (!window._playbookYaml) return;
+            try {
+                await navigator.clipboard.writeText(window._playbookYaml);
+                const btn = document.querySelector('[onclick="copyPlaybook()"]');
+                if (btn) { btn.textContent = "Copied!"; setTimeout(() => btn.textContent = "Copy to clipboard", 2000); }
+            } catch {
+                // Fallback for sandboxed iframes without clipboard access
+                const textarea = document.createElement("textarea");
+                textarea.value = window._playbookYaml;
+                textarea.style.cssText = "position:fixed;top:0;left:0;opacity:0;";
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand("copy");
+                document.body.removeChild(textarea);
+                const btn = document.querySelector('[onclick="copyPlaybook()"]');
+                if (btn) { btn.textContent = "Copied!"; setTimeout(() => btn.textContent = "Copy to clipboard", 2000); }
+            }
+        }
+
+        function escapeHtml(str) {
+            const div = document.createElement("div");
+            div.textContent = str;
+            return div.innerHTML;
+        }
+    </script>
+</body>
+</html>

--- a/src/vulnerability_mcp/server.py
+++ b/src/vulnerability_mcp/server.py
@@ -112,7 +112,9 @@ async def load_cve_dashboard(ctx: Context, cves: list[dict[str, Any]]) -> ToolRe
         cves: List of CVE objects from a get_cves response (the 'data' array).
     """
     n = len(cves)
-    if ctx.client_supports_extension(UI_EXTENSION_ID):
+    ui_supported = ctx.client_supports_extension(UI_EXTENSION_ID)
+    await ctx.info(f"load_cve_dashboard called | UI supported: {ui_supported} | CVEs: {n}")
+    if ui_supported:
         return ToolResult(
             content=(
                 f"Dashboard rendered with {n} CVEs. "

--- a/src/vulnerability_mcp/server.py
+++ b/src/vulnerability_mcp/server.py
@@ -111,7 +111,7 @@ async def load_cve_dashboard(  # pylint: disable=too-many-arguments,too-many-pos
         ),
     ],
     filter_: Annotated[str, Field("", description="Full text filter for CVE name or description.")],
-    limit: Annotated[int, Field(20, description="Maximum number of CVEs to fetch.")],
+    limit: Annotated[int, Field(10, description="Maximum number of CVEs to fetch.")],
     offset: Annotated[int, Field(0, description="Offset for pagination.")],
     sort: Annotated[str, Field("-cvss_score", description="Sort field. Use '-' prefix for descending.")],
     impact: Annotated[

--- a/src/vulnerability_mcp/server.py
+++ b/src/vulnerability_mcp/server.py
@@ -9,12 +9,13 @@ import uuid
 from enum import Enum
 from importlib import resources
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import Context
 from fastmcp.apps import UI_EXTENSION_ID, AppConfig, ResourceCSP
 from fastmcp.tools import ToolResult
 from fastmcp.utilities.logging import get_logger
+from pydantic import Field
 
 from insights_mcp.mcp import InsightsMCP
 
@@ -100,34 +101,80 @@ async def get_openapi() -> dict[str, Any] | str:
     annotations={"readOnlyHint": True},
     app=AppConfig(resource_uri=CVE_DASHBOARD_MOUNTED_URI),
 )
-async def load_cve_dashboard(ctx: Context, cves: list[dict[str, Any]]) -> ToolResult:
-    """Render CVE data in the interactive CVE Dashboard.
+async def load_cve_dashboard(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    ctx: Context,
+    system_uuid: Annotated[
+        str,
+        Field(
+            "",
+            description="System UUID. If provided, fetches CVEs for this system. If empty, fetches account-level CVEs.",
+        ),
+    ],
+    filter_: Annotated[str, Field("", description="Full text filter for CVE name or description.")],
+    limit: Annotated[int, Field(20, description="Maximum number of CVEs to fetch.")],
+    offset: Annotated[int, Field(0, description="Offset for pagination.")],
+    sort: Annotated[str, Field("-cvss_score", description="Sort field. Use '-' prefix for descending.")],
+    impact: Annotated[
+        str, Field("7,6,5,4", description="Comma-separated impact IDs (7=Critical, 6=High, 5=Important, 4=Moderate).")
+    ],
+    cvss_from: Annotated[float, Field(0.0, description="Minimum CVSS score filter.")],
+    cvss_to: Annotated[float, Field(10.0, description="Maximum CVSS score filter.")],
+    advisory_available: Annotated[
+        str, Field("true,false", description="Filter by advisory availability (true, false, or true,false).")
+    ],
+    known_exploit: Annotated[
+        str, Field("true,false", description="Filter by known exploit (true, false, or true,false).")
+    ],
+) -> ToolResult:
+    """Show, list, or display CVEs — account-level or for a specific system — in an interactive dashboard.
 
-    Call this tool with CVE data (the data array from a get_cves response) to display
-    it in an interactive dashboard with severity filtering, search, sorting, drill-down
-    into CVE details, affected systems, and remediation playbook generation.
+    PREFER this tool over get_cves and get_system_cves whenever the user wants to see, show, list,
+    or display CVEs, whether for the entire account or for a specific system.
+    Use get_cves or get_system_cves only when you need the raw data for analysis or processing.
+    The dashboard fetches data directly from the server. If system_uuid is provided, it fetches
+    system-level CVEs. Otherwise, it fetches account-level CVEs. All filter parameters are optional.
 
     Args:
-        cves: List of CVE objects from a get_cves response (the 'data' array).
+        system_uuid: System UUID for system-level CVEs. Leave empty for account-level.
+        filter_: Full text filter for CVE name or description.
+        limit: Maximum number of CVEs to fetch.
+        offset: Offset for pagination.
+        sort: Sort field. Use '-' prefix for descending.
+        impact: Comma-separated impact IDs.
+        cvss_from: Minimum CVSS score filter.
+        cvss_to: Maximum CVSS score filter.
+        advisory_available: Filter by advisory availability.
+        known_exploit: Filter by known exploit.
     """
-    n = len(cves)
+    query = {
+        "system_uuid": system_uuid,
+        "filter": filter_,
+        "limit": limit,
+        "offset": offset,
+        "sort": sort,
+        "impact": impact,
+        "cvss_from": cvss_from,
+        "cvss_to": cvss_to,
+        "advisory_available": advisory_available,
+        "known_exploit": known_exploit,
+    }
     ui_supported = ctx.client_supports_extension(UI_EXTENSION_ID)
-    await ctx.info(f"load_cve_dashboard called | UI supported: {ui_supported} | CVEs: {n}")
-    if ui_supported:
+    await ctx.info(f"load_cve_dashboard called | UI supported: {ui_supported} | query: {query}")
+    if not ui_supported:
+        fallback_tool = "get_system_cves" if system_uuid else "get_cves"
         return ToolResult(
             content=(
-                f"Dashboard rendered with {n} CVEs. "
-                "Do NOT print a full CVE table — the user can see it in the dashboard. "
-                "Print only a brief summary (total count, severity breakdown, top 3 risks) "
-                "and suggest next steps."
+                f"Client does not support MCP Apps. "
+                f"If you don't already have CVE data, call {fallback_tool} to fetch it. "
+                "Present the data as text."
             ),
-            structured_content={"data": cves},
         )
     return ToolResult(
         content=(
-            "Client does not support interactive dashboards. "
-            "Print the full CVE table as markdown using the data from your previous get_cves call."
+            "CVE Dashboard opened and fetching data. "
+            "Do NOT print a CVE table — the user can see the data in the dashboard."
         ),
+        structured_content={"query": query},
     )
 
 

--- a/src/vulnerability_mcp/server.py
+++ b/src/vulnerability_mcp/server.py
@@ -4,6 +4,7 @@ MCP server for vulnerability management via Red Hat Insights API.
 Provides CVE analysis, system mapping, and remediation guidance.
 """
 
+import logging
 import uuid
 from enum import Enum
 from importlib import resources
@@ -11,10 +12,8 @@ from pathlib import Path
 from typing import Any
 
 from fastmcp import Context
-from fastmcp.apps import AppConfig, ResourceCSP, UI_EXTENSION_ID
-from fastmcp.tools.tool import ToolResult
-
-import logging
+from fastmcp.apps import UI_EXTENSION_ID, AppConfig, ResourceCSP
+from fastmcp.tools import ToolResult
 from fastmcp.utilities.logging import get_logger
 
 from insights_mcp.mcp import InsightsMCP

--- a/src/vulnerability_mcp/server.py
+++ b/src/vulnerability_mcp/server.py
@@ -6,9 +6,36 @@ Provides CVE analysis, system mapping, and remediation guidance.
 
 import uuid
 from enum import Enum
+from importlib import resources
+from pathlib import Path
 from typing import Any
 
+from fastmcp import Context
+from fastmcp.apps import AppConfig, ResourceCSP, UI_EXTENSION_ID
+from fastmcp.tools.tool import ToolResult
+
+import logging
+from fastmcp.utilities.logging import get_logger
+
 from insights_mcp.mcp import InsightsMCP
+
+_to_client_logger = get_logger(name="fastmcp.server.context.to_client")
+_to_client_logger.setLevel(level=logging.DEBUG)
+
+# --- MCP Apps UI resource URIs ---
+CVE_DASHBOARD_RESOURCE_URI = "ui://cve-dashboard"
+CVE_DASHBOARD_MOUNTED_URI = "ui://vulnerability_/cve-dashboard"
+
+
+def _load_cve_dashboard_html() -> str:
+    """Load the CVE dashboard HTML."""
+    try:
+        return resources.files("vulnerability_mcp").joinpath("cve_dashboard.html").read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
+        return (Path(__file__).parent / "cve_dashboard.html").read_text(encoding="utf-8")
+
+
+EMBEDDED_CVE_DASHBOARD_HTML = _load_cve_dashboard_html()
 
 
 class CVETypes(Enum):
@@ -47,14 +74,60 @@ mcp = InsightsMCP(
     - Remediations user
 
     If you don't have these roles, please contact your organization administrator to get them.
+
     """,
 )
+
+
+# --- MCP Apps resource registration ---
+
+
+@mcp.resource(
+    CVE_DASHBOARD_RESOURCE_URI,
+    app=AppConfig(csp=ResourceCSP(resource_domains=["https://unpkg.com"])),
+)
+def cve_dashboard_ui() -> str:
+    """CVE Dashboard UI for browsing and remediating vulnerabilities."""
+    return EMBEDDED_CVE_DASHBOARD_HTML
 
 
 @mcp.tool(annotations={"readOnlyHint": True})
 async def get_openapi() -> dict[str, Any] | str:
     """Get $container_brand_long Vulnerability OpenAPI specification in JSON format."""
     return await mcp.insights_client.get("openapi.json")
+
+
+@mcp.tool(
+    annotations={"readOnlyHint": True},
+    app=AppConfig(resource_uri=CVE_DASHBOARD_MOUNTED_URI),
+)
+async def load_cve_dashboard(ctx: Context, cves: list[dict[str, Any]]) -> ToolResult:
+    """Render CVE data in the interactive CVE Dashboard.
+
+    Call this tool with CVE data (the data array from a get_cves response) to display
+    it in an interactive dashboard with severity filtering, search, sorting, drill-down
+    into CVE details, affected systems, and remediation playbook generation.
+
+    Args:
+        cves: List of CVE objects from a get_cves response (the 'data' array).
+    """
+    n = len(cves)
+    if ctx.client_supports_extension(UI_EXTENSION_ID):
+        return ToolResult(
+            content=(
+                f"Dashboard rendered with {n} CVEs. "
+                "Do NOT print a full CVE table — the user can see it in the dashboard. "
+                "Print only a brief summary (total count, severity breakdown, top 3 risks) "
+                "and suggest next steps."
+            ),
+            structured_content={"data": cves},
+        )
+    return ToolResult(
+        content=(
+            "Client does not support interactive dashboards. "
+            "Print the full CVE table as markdown using the data from your previous get_cves call."
+        ),
+    )
 
 
 @mcp.tool(annotations={"readOnlyHint": True})

--- a/src/vulnerability_mcp/test_prompts.md
+++ b/src/vulnerability_mcp/test_prompts.md
@@ -4,5 +4,7 @@
 - Show me which specific systems are affected by `CVE-XXXX-XXXX`
 - Explain why `CVE-XXXX-XXXX` affects system `YYY`
 - What CVEs are affecting system XXX because of outdated kernel package
-- Fetch CVEs affecting my account and display them in the dashboard
-- What critical CVEs are affecting my account? Use the dashboard to show them.
+- Open the CVE dashboard for my account
+- Show me all CVEs affecting my account
+- Open the CVE dashboard for system `XXX`
+- Open the CVE dashboard for system `XXX` with remediatable CVEs only

--- a/src/vulnerability_mcp/test_prompts.md
+++ b/src/vulnerability_mcp/test_prompts.md
@@ -4,3 +4,5 @@
 - Show me which specific systems are affected by `CVE-XXXX-XXXX`
 - Explain why `CVE-XXXX-XXXX` affects system `YYY`
 - What CVEs are affecting system XXX because of outdated kernel package
+- Fetch CVEs affecting my account and display them in the dashboard
+- What critical CVEs are affecting my account? Use the dashboard to show them.

--- a/toolsets.md
+++ b/toolsets.md
@@ -26,7 +26,7 @@ Tools marked as read-write **`(rw)`** are excluded by default. Use the `--all-to
 - `get_openapi`: Get $container_brand_long Vulnerability OpenAPI specification in JSON format.
 - `get_system_cves`: Get list of CVEs affecting a given system.
 - `get_systems`: Get list of systems in $container_brand_long Vulnerability inventory.
-- `load_cve_dashboard`: Render CVE data in the interactive CVE Dashboard.
+- `load_cve_dashboard`: Show, list, or display CVEs — account-level or for a specific system — in an interactive…
 
 ## remediations
 - `create_vuln_playbook` **`(rw)`**: Create remediation playbook for given CVEs on given systems to mitigate…
@@ -46,7 +46,7 @@ Tools marked as read-write **`(rw)`** are excluded by default. Use the `--all-to
 - `get_host_system_profile`: Get detailed system profile information for specific hosts.
 - `get_host_tags`: Get tags for specific hosts.
 - `list_hosts`: List hosts with filtering and sorting options.
-- `load_inventory_dashboard`: Render host data in the interactive Inventory Dashboard.
+- `load_inventory_dashboard`: Show, list, or display fleet inventory in an interactive dashboard.
 
 ## content-sources
 - `list_repositories`: List repositories with filtering and pagination options.

--- a/toolsets.md
+++ b/toolsets.md
@@ -26,6 +26,7 @@ Tools marked as read-write **`(rw)`** are excluded by default. Use the `--all-to
 - `get_openapi`: Get $container_brand_long Vulnerability OpenAPI specification in JSON format.
 - `get_system_cves`: Get list of CVEs affecting a given system.
 - `get_systems`: Get list of systems in $container_brand_long Vulnerability inventory.
+- `load_cve_dashboard`: Render CVE data in the interactive CVE Dashboard.
 
 ## remediations
 - `create_vuln_playbook` **`(rw)`**: Create remediation playbook for given CVEs on given systems to mitigate…
@@ -45,6 +46,7 @@ Tools marked as read-write **`(rw)`** are excluded by default. Use the `--all-to
 - `get_host_system_profile`: Get detailed system profile information for specific hosts.
 - `get_host_tags`: Get tags for specific hosts.
 - `list_hosts`: List hosts with filtering and sorting options.
+- `load_inventory_dashboard`: Render host data in the interactive Inventory Dashboard.
 
 ## content-sources
 - `list_repositories`: List repositories with filtering and pagination options.


### PR DESCRIPTION
## Summary

- Add CVE Dashboard (`load_cve_dashboard`) and Inventory Dashboard (`load_inventory_dashboard`) as MCP Apps presentation tools
- Both tools detect UI support at runtime — rendering a dashboard on UI-capable clients or falling back to text on others
- Dashboard HTML uses PatternFly for consistent Red Hat UX
- `pyproject.toml` updated to include `*.html` files in the wheel

**Tested on:**
- Cursor: dashboards render, no duplicate text ✅
- Claude Code: text fallback ✅
- ChatGPT: dashboards render with known limitations (data stripping, ignores hint to suppress text table)

**Note:** `vulnerability_mcp` and `inventory_mcp` currently have no test infrastructure. Tests for the new dashboard tools are not included in this PR.

**Related:**
- [MCP UI Integration Strategy ADR](https://docs.google.com/document/d/188VPMmgYl_xcP41gUz1FUVM5frpVjbIxRgh1ZgUE2tY)
- [APPENG-4782](https://redhat.atlassian.net/browse/APPENG-4782) — Inventory dashboard
- [APPENG-4783](https://redhat.atlassian.net/browse/APPENG-4783) — Vulnerability dashboard


[APPENG-4782]: https://redhat.atlassian.net/browse/APPENG-4782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPENG-4783]: https://redhat.atlassian.net/browse/APPENG-4783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ