### PR TITLE
Disable FastMCP version check (HMS-10797)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -47,6 +47,9 @@ ENV INSIGHTS_MCP_VERSION=${INSIGHTS_MCP_VERSION}
 ARG CONTAINER_BRAND=insights
 ENV CONTAINER_BRAND=${CONTAINER_BRAND}
 
+# Disable FastMCP version check
+ENV FASTMCP_CHECK_FOR_UPDATES=off
+
 # MCP Registry ownership verification label
 LABEL io.modelcontextprotocol.server.name="io.github.RedHatInsights/insights-mcp"
 


### PR DESCRIPTION
Disables [FastMCP version check ](https://github.com/PrefectHQ/fastmcp/pull/2839) introduced in [FastMCP version 2.14.3](https://github.com/PrefectHQ/fastmcp/releases/tag/v2.14.3).

Now there is no banner in the output like this:
<img width="920" height="85" alt="image" src="https://github.com/user-attachments/assets/35b6d390-f8b9-4433-99f2-c19859c53ef7" />
And no version check in the background either (accessible via --debug option):
```
2026-05-08 10:05:01 - INFO - _client.py:1025 - httpx - HTTP Request: GET https://pypi.org/pypi/fastmcp/json "HTTP/1.1 200 OK"
```

