### PR TITLE
ci: pin GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up QEMU
         run: |
@@ -115,7 +115,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build claude extension
         env:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Install aspell for pyspelling
         run: sudo apt install -y aspell

--- a/.github/workflows/publish-mcp.yaml
+++ b/.github/workflows/publish-mcp.yaml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.14'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Install deps and run tests
         run: |
@@ -32,8 +32,19 @@ jobs:
           make test
 
       - name: Install MCP Publisher
+        env:
+          # Manual/MintMaker bump: set both from the same GitHub release.
+          # Dependabot does not update these; MintMaker customManagers does.
+          MCP_PUBLISHER_VERSION: v1.8.0
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz
+          set -euo pipefail
+          ARCHIVE="mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${ARCHIVE}" \
+            -o "${ARCHIVE}"
+          echo "${MCP_PUBLISHER_SHA256}  ${ARCHIVE}" | sha256sum -c -
+          tar xzf "${ARCHIVE}" mcp-publisher
           chmod +x mcp-publisher
           sudo mv mcp-publisher /usr/local/bin/
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.yamllint
+++ b/.yamllint
@@ -4,6 +4,12 @@ extends: default
 rules:
   document-start: disable
   line-length: disable
+  # Pinact/Renovate use one space before "# vX.Y.Z" on action pins; yamllint's
+  # default wants two (PEP 8–style). Exempt .github only — keep the default
+  # elsewhere. Yamllint has no per-path min-spaces override, only rule ignore.
+  comments:
+    ignore: |
+      .github/
 
 ignore: |
   .tekton/

--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,21 @@
         "automergeType": "pr",
         "enabled": true,
         "platformAutomerge": true
-    }
+    },
+    "customManagers": [
+        {
+            "customType": "regex",
+            "description": "Pin mcp-publisher release + linux/amd64 asset digest",
+            "managerFilePatterns": [
+                "/^\\.github/workflows/publish-mcp\\.yaml$/"
+            ],
+            "matchStrings": [
+                "MCP_PUBLISHER_VERSION:\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s+MCP_PUBLISHER_SHA256:\\s*(?<currentDigest>[a-f0-9]{64})"
+            ],
+            "depNameTemplate": "modelcontextprotocol/registry",
+            "datasourceTemplate": "github-release-attachments",
+            "extractVersionTemplate": "^v(?<version>.*)$",
+            "packageNameTemplate": "modelcontextprotocol/registry"
+        }
+    ]
 }


### PR DESCRIPTION
Pin actions to full commit digests with version comments so CI does not follow mutable tags (e.g. @v7) that could be moved.

Also pin mcp-publisher to a release version and verify the tarball SHA256 instead of curling releases/latest. Teach MintMaker (customManagers + github-release-attachments) to bump that VERSION/SHA256 pair.

Exempt `.github/` from yamllint's comments spacing rule so Renovate's one-space `# vX.Y.Z` style does not fail lint.