### PR TITLE
refactor: extract shared dashboard CSS/JS into common assets

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -141,25 +141,43 @@ For multiuser scenarios (SSE/HTTP transports with header-based authentication), 
 
 ### Adding a New MCP App
 
-#### 1. Create the HTML file
+#### 1. Create the HTML template and dashboard-specific CSS
 
-Create `src/<toolset_mcp>/<app_name>.html`.
+Create `src/<toolset_mcp>/<app_name>.html` and `src/<toolset_mcp>/<app_name>.css`.
+
+The HTML template uses placeholders that get replaced at load time with shared assets:
+
+- `/* __DASHBOARD_BASE_CSS__ */` — shared base CSS (themes, layout, buttons, severity badges, pagination)
+- `/* __DASHBOARD_EXTRA_CSS__ */` — dashboard-specific CSS from the `.css` file
+- `/* __DASHBOARD_COMMON_JS__ */` — shared JS utilities (`callTool`, `showError`, `severityLabel`, `connectMcpApp`, etc.)
+- `<!-- __DASHBOARD_ICON__ -->` — Red Hat icon `<img>` tag
+
+Shared assets live in `src/insights_mcp/assets/` (`dashboard_base.css`, `dashboard_common.js`). Dashboard-specific styles go in the `.css` file alongside the template. Use CSS variables from the base CSS (e.g., `var(--text-primary)`, `var(--border-light)`) — never hardcode theme-dependent colors in templates or inline styles.
+
+Use `connectMcpApp()` from the common JS instead of manually loading the MCP Apps SDK:
+
+```javascript
+connectMcpApp("My App", "1.0.0", (query) => fetchMyData(query));
+```
 
 #### 2. Load the HTML at module level
 
 In `src/<toolset_mcp>/server.py`:
 
 ```python
-from importlib import resources
-from pathlib import Path
+from insights_mcp.dashboard_ui import load_dashboard_html
 
-def _load_my_app_html() -> str:
-    try:
-        return resources.files("my_toolset_mcp").joinpath("my_app.html").read_text(encoding="utf-8")
-    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
-        return (Path(__file__).parent / "my_app.html").read_text(encoding="utf-8")
+EMBEDDED_MY_APP_HTML = load_dashboard_html(
+    "my_toolset_mcp",
+    "my_app.html",
+    "my_app.css",
+)
+```
 
-EMBEDDED_MY_APP_HTML = _load_my_app_html()
+Update `pyproject.toml` to include the new file types in `[tool.setuptools.package-data]`:
+
+```toml
+my_toolset_mcp = ["*.html", "*.css"]
 ```
 
 #### 3. Define resource and mounted URIs
@@ -214,29 +232,27 @@ async def load_my_app(ctx: Context, ...) -> ToolResult:
 
 #### 6. Connect the HTML to MCP Apps SDK
 
-> **Dark mode:** Use CSS variables on `:root` (light) and `[data-theme="dark"]` (dark), toggled by the `onhostcontextchanged` callback. Use `background: transparent` on body to inherit the host app's background.
+> **Dark mode:** The shared base CSS defines CSS variables on `:root` (light) and `[data-theme="dark"]` (dark). The `connectMcpApp()` utility from `dashboard_common.js` handles theme switching automatically. Use `background: transparent` on body to inherit the host app's background. Use CSS variables (e.g., `var(--text-secondary)`) — never hardcode theme-dependent colors.
+
+The shared `dashboard_common.js` (injected via the `/* __DASHBOARD_COMMON_JS__ */` placeholder) provides:
+
+- `connectMcpApp(appName, version, onToolResult)` — loads the MCP Apps SDK, handles theme, wires `ontoolresult`
+- `callTool(name, args)` — wraps `callServerTool` with error handling and JSON parsing
+- `showError(msg)` / `hideError()` — alert banner management
+- `severityLabel(impact)` / `severityClass(impact)` — severity badge mapping
+- `renderPageButtons(current, total, containerEl)` — pagination with ellipsis
+- `escapeHtml(str)` — HTML escaping
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@5.4.2/patternfly.min.css">
-
 <script type="module">
-    import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
-        const App = module.App || module.default?.App || module.default;
-        const app = new (App.App || App)({ name: "My App", version: "1.0.0" });
-        app.connect();
-        window.mcpApp = app;
+/* __DASHBOARD_COMMON_JS__ */
 
-        app.onhostcontextchanged = (ctx) => {
-            const theme = ctx?.theme || "light";
-            document.documentElement.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
-        };
+    connectMcpApp("My App", "1.0.0", (query) => fetchMyData(query));
 
-        app.ontoolresult = (result) => {
-            const data = result.structuredContent;  // structured_content from the ToolResult
-            const content = result.content;             // content from the ToolResult
-            // render data
-        };
-    });
+    async function fetchMyData(query) {
+        const result = await callTool("my_toolset__my_tool", { param: query.param });
+        // render result
+    }
 </script>
 ```
 
@@ -260,12 +276,21 @@ Add 1-2 example prompts to `src/<toolset_mcp>/test_prompts.md` that exercise the
 
 - [PatternFly](https://www.patternfly.org/) — CSS framework used for styling MCP Apps in this project
 
+### Shared Dashboard Assets
+
+Shared CSS and JS live in [`src/insights_mcp/assets/`](src/insights_mcp/assets/):
+
+- [`dashboard_base.css`](src/insights_mcp/assets/dashboard_base.css) — theme variables, layout, buttons, severity badges, pagination, filters
+- [`dashboard_common.js`](src/insights_mcp/assets/dashboard_common.js) — `callTool`, `showError`, `severityLabel`, `connectMcpApp`, etc.
+
+The composition helper [`src/insights_mcp/dashboard_ui.py`](src/insights_mcp/dashboard_ui.py) replaces placeholders in HTML templates with these shared assets, producing self-contained HTML for MCP Apps.
+
 ### Existing Apps
 
 Use these as reference implementations:
 
-- **CVE Dashboard**: [`src/vulnerability_mcp/cve_dashboard.html`](src/vulnerability_mcp/cve_dashboard.html) + [`server.py`](src/vulnerability_mcp/server.py)
-- **Inventory Dashboard**: [`src/inventory_mcp/inventory_dashboard.html`](src/inventory_mcp/inventory_dashboard.html) + [`server.py`](src/inventory_mcp/server.py)
+- **CVE Dashboard**: [`cve_dashboard.html`](src/vulnerability_mcp/cve_dashboard.html) + [`cve_dashboard.css`](src/vulnerability_mcp/cve_dashboard.css) + [`server.py`](src/vulnerability_mcp/server.py)
+- **Inventory Dashboard**: [`inventory_dashboard.html`](src/inventory_mcp/inventory_dashboard.html) + [`inventory_dashboard.css`](src/inventory_mcp/inventory_dashboard.css) + [`server.py`](src/inventory_mcp/server.py)
 
 ## Important notes
 * When changing some code you might want to use `make build-prod` so the container is built with

--- a/docs/mkdocs/HACKING.md
+++ b/docs/mkdocs/HACKING.md
@@ -141,25 +141,43 @@ For multiuser scenarios (SSE/HTTP transports with header-based authentication), 
 
 ### Adding a New MCP App
 
-#### 1. Create the HTML file
+#### 1. Create the HTML template and dashboard-specific CSS
 
-Create `src/<toolset_mcp>/<app_name>.html`.
+Create `src/<toolset_mcp>/<app_name>.html` and `src/<toolset_mcp>/<app_name>.css`.
+
+The HTML template uses placeholders that get replaced at load time with shared assets:
+
+- `/* __DASHBOARD_BASE_CSS__ */` — shared base CSS (themes, layout, buttons, severity badges, pagination)
+- `/* __DASHBOARD_EXTRA_CSS__ */` — dashboard-specific CSS from the `.css` file
+- `/* __DASHBOARD_COMMON_JS__ */` — shared JS utilities (`callTool`, `showError`, `severityLabel`, `connectMcpApp`, etc.)
+- `<!-- __DASHBOARD_ICON__ -->` — Red Hat icon `<img>` tag
+
+Shared assets live in `src/insights_mcp/assets/` (`dashboard_base.css`, `dashboard_common.js`). Dashboard-specific styles go in the `.css` file alongside the template. Use CSS variables from the base CSS (e.g., `var(--text-primary)`, `var(--border-light)`) — never hardcode theme-dependent colors in templates or inline styles.
+
+Use `connectMcpApp()` from the common JS instead of manually loading the MCP Apps SDK:
+
+```javascript
+connectMcpApp("My App", "1.0.0", (query) => fetchMyData(query));
+```
 
 #### 2. Load the HTML at module level
 
 In `src/<toolset_mcp>/server.py`:
 
 ```python
-from importlib import resources
-from pathlib import Path
+from insights_mcp.dashboard_ui import load_dashboard_html
 
-def _load_my_app_html() -> str:
-    try:
-        return resources.files("my_toolset_mcp").joinpath("my_app.html").read_text(encoding="utf-8")
-    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
-        return (Path(__file__).parent / "my_app.html").read_text(encoding="utf-8")
+EMBEDDED_MY_APP_HTML = load_dashboard_html(
+    "my_toolset_mcp",
+    "my_app.html",
+    "my_app.css",
+)
+```
 
-EMBEDDED_MY_APP_HTML = _load_my_app_html()
+Update `pyproject.toml` to include the new file types in `[tool.setuptools.package-data]`:
+
+```toml
+my_toolset_mcp = ["*.html", "*.css"]
 ```
 
 #### 3. Define resource and mounted URIs
@@ -214,29 +232,27 @@ async def load_my_app(ctx: Context, ...) -> ToolResult:
 
 #### 6. Connect the HTML to MCP Apps SDK
 
-> **Dark mode:** Use CSS variables on `:root` (light) and `[data-theme="dark"]` (dark), toggled by the `onhostcontextchanged` callback. Use `background: transparent` on body to inherit the host app's background.
+> **Dark mode:** The shared base CSS defines CSS variables on `:root` (light) and `[data-theme="dark"]` (dark). The `connectMcpApp()` utility from `dashboard_common.js` handles theme switching automatically. Use `background: transparent` on body to inherit the host app's background. Use CSS variables (e.g., `var(--text-secondary)`) — never hardcode theme-dependent colors.
+
+The shared `dashboard_common.js` (injected via the `/* __DASHBOARD_COMMON_JS__ */` placeholder) provides:
+
+- `connectMcpApp(appName, version, onToolResult)` — loads the MCP Apps SDK, handles theme, wires `ontoolresult`
+- `callTool(name, args)` — wraps `callServerTool` with error handling and JSON parsing
+- `showError(msg)` / `hideError()` — alert banner management
+- `severityLabel(impact)` / `severityClass(impact)` — severity badge mapping
+- `renderPageButtons(current, total, containerEl)` — pagination with ellipsis
+- `escapeHtml(str)` — HTML escaping
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@5.4.2/patternfly.min.css">
-
 <script type="module">
-    import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
-        const App = module.App || module.default?.App || module.default;
-        const app = new (App.App || App)({ name: "My App", version: "1.0.0" });
-        app.connect();
-        window.mcpApp = app;
+/* __DASHBOARD_COMMON_JS__ */
 
-        app.onhostcontextchanged = (ctx) => {
-            const theme = ctx?.theme || "light";
-            document.documentElement.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
-        };
+    connectMcpApp("My App", "1.0.0", (query) => fetchMyData(query));
 
-        app.ontoolresult = (result) => {
-            const data = result.structuredContent;  // structured_content from the ToolResult
-            const content = result.content;             // content from the ToolResult
-            // render data
-        };
-    });
+    async function fetchMyData(query) {
+        const result = await callTool("my_toolset__my_tool", { param: query.param });
+        // render result
+    }
 </script>
 ```
 
@@ -260,12 +276,21 @@ Add 1-2 example prompts to `src/<toolset_mcp>/test_prompts.md` that exercise the
 
 - [PatternFly](https://www.patternfly.org/) — CSS framework used for styling MCP Apps in this project
 
+### Shared Dashboard Assets
+
+Shared CSS and JS live in [`src/insights_mcp/assets/`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/insights_mcp/assets/):
+
+- [`dashboard_base.css`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/insights_mcp/assets/dashboard_base.css) — theme variables, layout, buttons, severity badges, pagination, filters
+- [`dashboard_common.js`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/insights_mcp/assets/dashboard_common.js) — `callTool`, `showError`, `severityLabel`, `connectMcpApp`, etc.
+
+The composition helper [`src/insights_mcp/dashboard_ui.py`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/insights_mcp/dashboard_ui.py) replaces placeholders in HTML templates with these shared assets, producing self-contained HTML for MCP Apps.
+
 ### Existing Apps
 
 Use these as reference implementations:
 
-- **CVE Dashboard**: [`src/vulnerability_mcp/cve_dashboard.html`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/vulnerability_mcp/cve_dashboard.html) + [`server.py`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/vulnerability_mcp/server.py)
-- **Inventory Dashboard**: [`src/inventory_mcp/inventory_dashboard.html`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/inventory_mcp/inventory_dashboard.html) + [`server.py`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/inventory_mcp/server.py)
+- **CVE Dashboard**: [`cve_dashboard.html`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/vulnerability_mcp/cve_dashboard.html) + [`cve_dashboard.css`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/vulnerability_mcp/cve_dashboard.css) + [`server.py`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/vulnerability_mcp/server.py)
+- **Inventory Dashboard**: [`inventory_dashboard.html`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/inventory_mcp/inventory_dashboard.html) + [`inventory_dashboard.css`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/inventory_mcp/inventory_dashboard.css) + [`server.py`](https://github.com/RedHatInsights/insights-mcp/blob/main/src/inventory_mcp/server.py)
 
 ## Important notes
 * When changing some code you might want to use `make build-prod` so the container is built with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,9 @@ where = ["src", "scripts"]
 "" = "src"
 
 [tool.setuptools.package-data]
-insights_mcp = ["assets/*.png"]
-inventory_mcp = ["*.html"]
-vulnerability_mcp = ["*.html"]
+insights_mcp = ["assets/*"]
+inventory_mcp = ["*.html", "*.css"]
+vulnerability_mcp = ["*.html", "*.css"]
 
 [tool.pylint.format]
 max-line-length = 120

--- a/src/insights_mcp/assets/dashboard_base.css
+++ b/src/insights_mcp/assets/dashboard_base.css
@@ -1,0 +1,89 @@
+:root {
+    --bg-primary: #ffffff;
+    --bg-secondary: #f2f2f2;
+    --text-primary: #292929;
+    --text-secondary: #4d4d4d;
+    --border-color: #a3a3a3;
+    --border-light: #e0e0e0;
+    --header-bg: #292929;
+    --header-text: #ffffff;
+    --header-meta: #a3a3a3;
+    --row-hover: #f2f2f2;
+    --btn-bg: #e0e0e0;
+    --btn-text: #292929;
+    --input-bg: #ffffff;
+    --input-border: #a3a3a3;
+    --filter-bg: #ffffff;
+    --filter-text: #4d4d4d;
+    --filter-active-bg: #292929;
+    --filter-active-text: #ffffff;
+}
+[data-theme="dark"] {
+    --bg-primary: #1a1a1a;
+    --bg-secondary: #2a2a2a;
+    --text-primary: #e0e0e0;
+    --text-secondary: #a3a3a3;
+    --border-color: #4d4d4d;
+    --border-light: #333333;
+    --header-bg: #111111;
+    --header-text: #ffffff;
+    --header-meta: #a3a3a3;
+    --row-hover: #333333;
+    --btn-bg: #333333;
+    --btn-text: #e0e0e0;
+    --input-bg: #2a2a2a;
+    --input-border: #4d4d4d;
+    --filter-bg: #2a2a2a;
+    --filter-text: #a3a3a3;
+    --filter-active-bg: #e0e0e0;
+    --filter-active-text: #1a1a1a;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: var(--pf-v5-global--FontFamily--text); font-size: 13px; padding: 12px; background: transparent; color: var(--text-primary); min-height: 100vh; }
+.header { background: var(--header-bg); color: var(--header-text); padding: 8px 12px; border-radius: 6px; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; }
+.header-title { font-size: 14px; font-weight: 600; }
+.header-meta { font-size: 11px; color: var(--header-meta); }
+.card { background: var(--bg-primary); border-radius: 6px; border: 1px solid var(--border-color); margin-bottom: 12px; overflow: hidden; }
+.card-title { padding: 8px 12px; border-bottom: 1px solid var(--border-light); font-weight: 600; font-size: 13px; display: flex; align-items: center; gap: 8px; }
+.card-body { padding: 0; }
+.alert-danger { background: #fce3e3; border: 1px solid #a60000; color: #a60000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; }
+.detail-grid { display: grid; grid-template-columns: 120px 1fr; gap: 4px 12px; padding: 12px; font-size: 12px; }
+.detail-label { color: var(--text-secondary); font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: 0.5px; }
+.detail-value { color: var(--text-primary); word-break: break-word; }
+.severity { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; color: #ffffff; }
+.severity-critical { background: #a60000; }
+.severity-important { background: #ca6c0f; }
+.severity-moderate { background: #dca614; color: #292929; }
+.severity-low { background: #a3a3a3; }
+.severity-none { background: #e0e0e0; color: #4d4d4d; }
+.btn { padding: 4px 12px; border: none; border-radius: 4px; font-size: 12px; font-weight: 600; cursor: pointer; transition: opacity 0.1s; }
+.btn:hover { opacity: 0.85; }
+.btn-back { background: var(--btn-bg); color: var(--btn-text); }
+.btn-primary { background: #ee0000; color: #ffffff; }
+.btn-secondary { background: var(--header-bg); color: #ffffff; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.pagination { padding: 8px 12px; display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--text-secondary); border-top: 1px solid var(--border-light); }
+.loading { text-align: center; padding: 24px; color: var(--text-secondary); font-size: 12px; }
+.filters { padding: 8px 12px; border-bottom: 1px solid var(--border-light); display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+.filter-btn { padding: 2px 8px; border: 1px solid var(--border-color); border-radius: 12px; font-size: 11px; cursor: pointer; background: var(--filter-bg); color: var(--filter-text); transition: all 0.1s; }
+.filter-btn.active { background: var(--filter-active-bg); color: var(--filter-active-text); border-color: var(--filter-active-bg); }
+.filter-btn:hover { border-color: var(--text-primary); }
+.search-bar { padding: 8px 12px; border-bottom: 1px solid var(--border-light); display: flex; gap: 4px; align-items: center; }
+.search-bar input { flex: 1; padding: 4px 8px; border: 1px solid var(--input-border); border-radius: 4px; font-size: 12px; font-family: inherit; background: var(--input-bg); color: var(--text-primary); }
+.row-layout { display: flex; justify-content: space-between; align-items: center; }
+.row-end { display: flex; gap: 8px; align-items: center; }
+.card-actions { padding: 12px; display: flex; gap: 8px; }
+.page-buttons { display: flex; gap: 2px; align-items: center; flex-wrap: wrap; }
+.page-ellipsis { font-size: 11px; color: var(--text-secondary); padding: 0 2px; }
+.btn-page { min-width: 28px; padding: 4px 6px; }
+.btn-sm { padding: 4px 8px; }
+.filter-label { font-size: 11px; color: var(--text-secondary); }
+.filter-divider { margin-left: 8px; border-left: 1px solid var(--border-color); padding-left: 8px; }
+.select { font-size: 11px; border: 1px solid var(--input-border); border-radius: 4px; padding: 1px 4px; font-family: inherit; background: var(--input-bg); color: var(--text-primary); }
+.mono-sm { font-size: 11px; font-family: monospace; }
+.cve-id { font-weight: 600; font-size: 13px; color: var(--text-primary); font-family: var(--pf-v5-global--FontFamily--monospace); }
+.cvss { font-family: var(--pf-v5-global--FontFamily--monospace); font-size: 11px; font-weight: 600; }
+.desc-text { margin-bottom: 12px; font-size: 12px; color: var(--text-secondary); }
+a { color: #ee0000; text-decoration: none; }
+a:hover { text-decoration: underline; }
+.hidden { display: none !important; }

--- a/src/insights_mcp/assets/dashboard_common.js
+++ b/src/insights_mcp/assets/dashboard_common.js
@@ -1,0 +1,79 @@
+function showError(msg) {
+    const el = document.getElementById("alert");
+    el.textContent = msg;
+    el.classList.remove("hidden");
+}
+
+function hideError() {
+    document.getElementById("alert").classList.add("hidden");
+}
+
+async function callTool(name, args) {
+    if (!window.mcpApp) { showError("MCP App not connected"); return null; }
+    try {
+        const result = await window.mcpApp.callServerTool({ name, arguments: args });
+        const text = result.content?.find(c => c.type === "text")?.text;
+        if (!text) { showError("No response from server"); return null; }
+        try { return JSON.parse(text); } catch { showError(text); return null; }
+    } catch (e) {
+        showError(e.message || "Tool call failed");
+        return null;
+    }
+}
+
+function severityLabel(impact) {
+    if (typeof impact === "string") return impact;
+    const map = { 7: "Critical", 5: "Important", 4: "Moderate", 2: "Low", 1: "None", 0: "NotSet" };
+    return map[impact] || "Unknown";
+}
+
+function severityClass(impact) {
+    const label = (typeof impact === "string" ? impact : severityLabel(impact)).toLowerCase();
+    const map = { critical: "severity-critical", important: "severity-important", moderate: "severity-moderate", low: "severity-low", none: "severity-none", notset: "severity-none" };
+    return map[label] || "severity-none";
+}
+
+function renderPageButtons(current, total, containerEl) {
+    const show = new Set([1, total, current, current - 1, current + 1]);
+    if (current > 3) show.add(current - 2);
+    if (current < total - 2) show.add(current + 2);
+    const sorted = [...show].filter(p => p >= 1 && p <= total).sort((a, b) => a - b);
+    let html = `<button class="btn btn-back" onclick="goToPage(${current - 1})" ${current === 1 ? 'disabled' : ''}>&laquo;</button>`;
+    let prev = 0;
+    for (const p of sorted) {
+        if (prev && p - prev > 1) html += `<span class="page-ellipsis">...</span>`;
+        html += `<button class="btn btn-page ${p === current ? 'btn-secondary' : 'btn-back'}" onclick="goToPage(${p})">${p}</button>`;
+        prev = p;
+    }
+    html += `<button class="btn btn-back" onclick="goToPage(${current + 1})" ${current === total ? 'disabled' : ''}>&raquo;</button>`;
+    containerEl.innerHTML = html;
+}
+
+function escapeHtml(str) {
+    const div = document.createElement("div");
+    div.textContent = str;
+    return div.innerHTML;
+}
+
+function connectMcpApp(appName, appVersion, onToolResult) {
+    import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
+        const App = module.App || module.default?.App || module.default;
+        const app = new (App.App || App)({ name: appName, version: appVersion });
+        app.connect();
+        window.mcpApp = app;
+
+        app.onhostcontextchanged = (ctx) => {
+            const theme = ctx?.theme || "light";
+            document.documentElement.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
+        };
+
+        app.ontoolresult = (result) => {
+            const sc = result.structuredContent;
+            if (sc && sc.query) {
+                onToolResult(sc.query);
+            }
+        };
+    }).catch(err => {
+        showError("Failed to load MCP Apps SDK: " + err.message);
+    });
+}

--- a/src/insights_mcp/dashboard_ui.py
+++ b/src/insights_mcp/dashboard_ui.py
@@ -1,0 +1,89 @@
+"""Dashboard UI composition utilities.
+
+Composes self-contained HTML dashboards by combining shared assets
+(base CSS, common JS) with dashboard-specific templates and styles.
+"""
+
+import base64
+from importlib import resources
+from pathlib import Path
+
+
+def _read_asset(filename: str) -> str:
+    """Read a file from the insights_mcp.assets package."""
+    try:
+        return resources.files("insights_mcp.assets").joinpath(filename).read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
+        return (Path(__file__).parent / "assets" / filename).read_text(encoding="utf-8")
+
+
+def _read_package_file(package: str, filename: str) -> str:
+    """Read a file from a specific package."""
+    try:
+        return resources.files(package).joinpath(filename).read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
+        # Fallback for editable installs
+        pkg_dir = Path(__file__).parent.parent / package
+        return (pkg_dir / filename).read_text(encoding="utf-8")
+
+
+def get_icon_img_tag() -> str:
+    """Build an <img> tag with the Red Hat icon as a base64 data URI."""
+    try:
+        icon_data = resources.files("insights_mcp.assets").joinpath("icon.png").read_bytes()
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
+        icon_data = (Path(__file__).parent / "assets" / "icon.png").read_bytes()
+    icon_b64 = base64.b64encode(icon_data).decode("utf-8")
+    return (
+        f'<img src="data:image/png;base64,{icon_b64}" '
+        f'alt="Red Hat" style="height:16px;vertical-align:middle;margin-right:6px;">'
+    )
+
+
+def compose_dashboard_html(
+    template: str,
+    *,
+    base_css: str,
+    extra_css: str = "",
+    common_js: str,
+) -> str:
+    """Replace placeholders in a dashboard HTML template with shared assets.
+
+    Placeholders:
+        /* __DASHBOARD_BASE_CSS__ */   -> base CSS content
+        /* __DASHBOARD_EXTRA_CSS__ */  -> dashboard-specific CSS content
+        /* __DASHBOARD_COMMON_JS__ */  -> common JS utilities
+        <!-- __DASHBOARD_ICON__ -->    -> <img> tag with base64 icon
+    """
+    icon_tag = get_icon_img_tag()
+
+    html = template
+    html = html.replace("/* __DASHBOARD_BASE_CSS__ */", base_css)
+    html = html.replace("/* __DASHBOARD_EXTRA_CSS__ */", extra_css)
+    html = html.replace("/* __DASHBOARD_COMMON_JS__ */", common_js)
+    html = html.replace("<!-- __DASHBOARD_ICON__ -->", icon_tag)
+    return html
+
+
+def load_dashboard_html(
+    package: str,
+    template_name: str,
+    css_name: str,
+) -> str:
+    """Load and compose a dashboard HTML from package resources.
+
+    Reads the template HTML and dashboard-specific CSS from *package*,
+    reads shared base CSS and common JS from insights_mcp.assets,
+    and composes them into a self-contained HTML string.
+    """
+    template = _read_package_file(package, template_name)
+    extra_css = _read_package_file(package, css_name)
+    base_css = _read_asset("dashboard_base.css")
+    common_js = _read_asset("dashboard_common.js")
+
+    return compose_dashboard_html(
+        template,
+        base_css=base_css,
+        extra_css=extra_css,
+        common_js=common_js,
+    )

--- a/src/inventory_mcp/inventory_dashboard.css
+++ b/src/inventory_mcp/inventory_dashboard.css
@@ -1,0 +1,11 @@
+.host-row { padding: 8px 12px; border-bottom: 1px solid var(--border-light); cursor: pointer; transition: background 0.1s; }
+.host-row:hover { background: var(--row-hover); }
+.host-row:last-child { border-bottom: none; }
+.host-name { font-weight: 600; font-size: 13px; color: var(--text-primary); }
+.host-meta { font-size: 11px; color: var(--text-secondary); margin-top: 2px; }
+.staleness { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 10px; font-weight: 600; color: #ffffff; }
+.staleness-fresh { background: #3d7317; }
+.staleness-stale { background: #a60000; }
+.staleness-warning { background: #ca6c0f; }
+.staleness-unknown { background: #a3a3a3; }
+.nic-row { font-size: 11px; margin-bottom: 2px; }

--- a/src/inventory_mcp/inventory_dashboard.html
+++ b/src/inventory_mcp/inventory_dashboard.html
@@ -6,90 +6,13 @@
     <title>Inventory Dashboard</title>
     <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@5.4.2/patternfly.min.css">
     <style>
-        :root {
-            --bg-primary: #ffffff;
-            --bg-secondary: #f2f2f2;
-            --text-primary: #292929;
-            --text-secondary: #4d4d4d;
-            --border-color: #a3a3a3;
-            --border-light: #e0e0e0;
-            --header-bg: #292929;
-            --header-text: #ffffff;
-            --header-meta: #a3a3a3;
-            --row-hover: #f2f2f2;
-            --btn-bg: #e0e0e0;
-            --btn-text: #292929;
-            --input-bg: #ffffff;
-            --input-border: #a3a3a3;
-            --filter-bg: #ffffff;
-            --filter-text: #4d4d4d;
-            --filter-active-bg: #292929;
-            --filter-active-text: #ffffff;
-        }
-        [data-theme="dark"] {
-            --bg-primary: #1a1a1a;
-            --bg-secondary: #2a2a2a;
-            --text-primary: #e0e0e0;
-            --text-secondary: #a3a3a3;
-            --border-color: #4d4d4d;
-            --border-light: #333333;
-            --header-bg: #111111;
-            --header-text: #ffffff;
-            --header-meta: #a3a3a3;
-            --row-hover: #333333;
-            --btn-bg: #333333;
-            --btn-text: #e0e0e0;
-            --input-bg: #2a2a2a;
-            --input-border: #4d4d4d;
-            --filter-bg: #2a2a2a;
-            --filter-text: #a3a3a3;
-            --filter-active-bg: #e0e0e0;
-            --filter-active-text: #1a1a1a;
-        }
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: var(--pf-v5-global--FontFamily--text); font-size: 13px; padding: 12px; background: transparent; color: var(--text-primary); min-height: 100vh; }
-        .header { background: var(--header-bg); color: var(--header-text); padding: 8px 12px; border-radius: 6px; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; }
-        .header-title { font-size: 14px; font-weight: 600; }
-        .header-meta { font-size: 11px; color: var(--header-meta); }
-        .card { background: var(--bg-primary); border-radius: 6px; border: 1px solid var(--border-color); margin-bottom: 12px; overflow: hidden; }
-        .card-title { padding: 8px 12px; border-bottom: 1px solid var(--border-light); font-weight: 600; font-size: 13px; display: flex; align-items: center; gap: 8px; }
-        .card-body { padding: 0; }
-        .alert-danger { background: #fce3e3; border: 1px solid #a60000; color: #a60000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; }
-        .host-row { padding: 8px 12px; border-bottom: 1px solid var(--border-light); cursor: pointer; transition: background 0.1s; }
-        .host-row:hover { background: var(--row-hover); }
-        .host-row:last-child { border-bottom: none; }
-        .host-name { font-weight: 600; font-size: 13px; color: var(--text-primary); }
-        .host-meta { font-size: 11px; color: var(--text-secondary); margin-top: 2px; }
-        .staleness { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 10px; font-weight: 600; color: #ffffff; }
-        .staleness-fresh { background: #3d7317; }
-        .staleness-stale { background: #a60000; }
-        .staleness-warning { background: #ca6c0f; }
-        .staleness-unknown { background: #a3a3a3; }
-        .detail-grid { display: grid; grid-template-columns: 120px 1fr; gap: 4px 12px; padding: 12px; font-size: 12px; }
-        .detail-label { color: var(--text-secondary); font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: 0.5px; }
-        .detail-value { color: var(--text-primary); word-break: break-word; }
-        .btn { padding: 4px 12px; border: none; border-radius: 4px; font-size: 12px; font-weight: 600; cursor: pointer; transition: opacity 0.1s; }
-        .btn:hover { opacity: 0.85; }
-        .btn-back { background: var(--btn-bg); color: var(--btn-text); }
-        .btn-secondary { background: var(--header-bg); color: #ffffff; }
-        .pagination { padding: 8px 12px; display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--text-secondary); border-top: 1px solid var(--border-light); }
-        .loading { text-align: center; padding: 24px; color: var(--text-secondary); font-size: 12px; }
-        .search-bar { padding: 8px 12px; border-bottom: 1px solid var(--border-light); display: flex; gap: 4px; align-items: center; }
-        .search-bar input { flex: 1; padding: 4px 8px; border: 1px solid var(--input-border); border-radius: 4px; font-size: 12px; font-family: inherit; background: var(--input-bg); color: var(--text-primary); }
-        .nic-row { font-size: 11px; margin-bottom: 2px; }
-        .sev-critical { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#ffffff;background:#a60000; }
-        .sev-important { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#ffffff;background:#ca6c0f; }
-        .sev-moderate { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#292929;background:#dca614; }
-        .sev-low { display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:#ffffff;background:#a3a3a3; }
-        .filter-btn { padding: 2px 8px; border: 1px solid var(--border-color); border-radius: 12px; font-size: 11px; cursor: pointer; background: var(--filter-bg); color: var(--filter-text); transition: all 0.1s; }
-        .filter-btn.active { background: var(--filter-active-bg); color: var(--filter-active-text); border-color: var(--filter-active-bg); }
-        .filter-btn:hover { border-color: var(--text-primary); }
-        .hidden { display: none !important; }
+/* __DASHBOARD_BASE_CSS__ */
+/* __DASHBOARD_EXTRA_CSS__ */
     </style>
 </head>
 <body>
     <div class="header">
-        <span class="header-title"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAdnJLH8AAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+kHHQcvBP3yWUkAAASbSURBVGje7dl5iFVVHAfwz5k3Y+OS5jNN29Boo73Esn0RKouIVtqJVuwPkQiigooWKdIsqKiICoMKIioKyRawohXbixYyKiTavNrY4ujMO/1xjvEcxnlvxvfGgvnCgffuPffc3/ec334ZwhCG8L9GaObiBSMxFh1YXSb+ZwgUbIuTMREf4rUyK6vu74ZbMRU/4V28gvfwa6PIhAEKPxEPY2a+1JkFeyKT2RFXYVqPR9fgK7yIZ/FROV0bdALX4ZZeblXwF4bl0RdW4jU8hlfL/D4oBPLuL8Y+DVLjNXgb92FROW1A3WgZwAunS/rdKLTjaCzEAwVTmkagSPNPxBZNcFrDcR7uKRjXrBPYAUc12bUfi+OaReBw/TziAaAVRzScQJEWPgGlQQiw+xaMbvQJ7IRDBylDmJLVtXEEvuWoWOeiDcA47NFIAiNv57TVhDA4BFpxQL0Te+p6wJaYgAkjGHs9e93N9P0xK0e/2HwS+xe010o1WqsEH4XDsp+fhu0xppMthtPSSekOjCaeTWhpPoldc6L4XU0CBXvhpux/R1RPiPgly7oS1xJ+JV6GUYTu5hGYiF1qEWjJae9DOKWn8OuTpWrH34G5hNn4glhqXlExvLMOO2jBbBy0sQkRM7Bzlcasw9OEc3A/sWgSkU9TLdHa15zS1SzQR+4R080wAksI6zbMh8MSwts5uk3KatUI++jGI5S2ZvHXrOjrBMbUWiziTMIcYnuPe12p1AqzCWdgAfEz4tq8df09mZCfe4e4iF1m8eSfXFFQ7nV+wSfYu56F1+JB4nzCqj7mjSdOzQnNVEzGVoRhNQJPd3Io8SXMT8EzPEw8le4uluBGvFVdjoaCebiyno0KueRaTJyLz2o8E5JKxe1yHjIl+ea4dbqulPn8TeVnwldYii8JnXmNO+m+hFJX+rsc1+DxchKFIiVO3xTZGOsZvxM/pjKLyri0UOzPCMRWYlsepY3MG0Z8gkrHhu8vCi7YoKQskieah7b+pLFdeJ/4KF7CigY7okOIC7MT6eEUfsRZZd4IVVH4LlzUX29YyrbxKfE5vIxlVSowUOxJXIADCZXepyzCuaEqlZiAe3HaQFx6KdvHL8QPcrthaQ6jqwhddZ7qJOJMXJ7C8MaEhz9xceiRyG2D23Jt2jrQNkcpe5QO4vJ0IpYRf0gEQwdxTVKL0EZlLGHH3OaYlgw+rN+QGlgYeslGR2evNKeeGFGLTEvVcXZnu1lH7MqXS8mQ/3WxlfoEX483Qx/l40m4Afs2uym7CVH79V7jSpmuMs/kBO+epMaNRbW/3AQsC3UU8204MqvUjNyI+i9gDS4N/ehKjMrN3Mty4bO5ibyB0wfSGx2NY3B+bgmO3QzCF7iwzPOb8n2gHfvh1Hwyu6rdkW4EVkrd8QfKVEIDtiJI8WM6js/qtVPudTYSFenbw814oZy8cmNzl9z8HZ/T84NTJmD3XN+OHOD7OlKm4ik8VU550KB9IxuW2zOTs4rtnH9PzLYzMqvd+k7NWvyB3/B9FnwpPt/YB5CwGayvRWrPt+fRVkWgK5UH/kZneVDaT0MYwhA2K/4BI+BgELD+CNsAAAAASUVORK5CYII=" alt="Red Hat" style="height:16px;vertical-align:middle;margin-right:6px;">Red Hat Lightspeed — Inventory</span>
+        <span class="header-title"><!-- __DASHBOARD_ICON__ -->Red Hat Lightspeed — Inventory</span>
         <span class="header-meta" id="total-count"></span>
     </div>
 
@@ -101,18 +24,18 @@
             <div class="card-title">Fleet</div>
             <div class="search-bar">
                 <input type="text" id="search-input" placeholder="Search by hostname or FQDN" onkeydown="if(event.key==='Enter')searchHosts()">
-                <button class="btn btn-secondary" onclick="searchHosts()" style="padding:4px 8px;">Search</button>
-                <button class="btn btn-back" onclick="clearSearch()" style="padding:4px 8px;">Clear</button>
+                <button class="btn btn-sm btn-secondary" onclick="searchHosts()">Search</button>
+                <button class="btn btn-sm btn-back" onclick="clearSearch()">Clear</button>
             </div>
-            <div class="filters" style="padding:8px 12px;border-bottom:1px solid var(--border-light);display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
-                <span style="font-size:11px;color:var(--text-secondary);">Staleness:</span>
+            <div class="filters">
+                <span class="filter-label">Staleness:</span>
                 <button class="filter-btn active" data-staleness="" onclick="filterStaleness(this)">All</button>
                 <button class="filter-btn" data-staleness="fresh" onclick="filterStaleness(this)">Fresh</button>
                 <button class="filter-btn" data-staleness="stale" onclick="filterStaleness(this)">Stale</button>
                 <button class="filter-btn" data-staleness="stale_warning" onclick="filterStaleness(this)">Stale warning</button>
-                <span style="margin-left:8px;border-left:1px solid var(--border-color);padding-left:8px;">
-                    <label style="font-size:11px;color:var(--text-secondary);">Sort:
-                        <select id="sort-select" onchange="changeSort()" style="font-size:11px;border:1px solid var(--input-border);border-radius:4px;padding:1px 4px;font-family:inherit;background:var(--input-bg);color:var(--text-primary);">
+                <span class="filter-divider">
+                    <label class="filter-label">Sort:
+                        <select id="sort-select" onchange="changeSort()" class="select">
                             <option value="display_name" data-dir="ASC">Name (A-Z)</option>
                             <option value="display_name" data-dir="DESC">Name (Z-A)</option>
                             <option value="updated" data-dir="DESC" selected>Updated (newest)</option>
@@ -128,7 +51,7 @@
             </div>
             <div class="pagination hidden" id="pagination">
                 <span id="page-info"></span>
-                <div id="page-buttons" style="display:flex;gap:2px;align-items:center;flex-wrap:wrap;"></div>
+                <div id="page-buttons" class="page-buttons"></div>
             </div>
         </div>
     </div>
@@ -186,26 +109,9 @@
     </div>
 
     <script type="module">
-        import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
-            const App = module.App || module.default?.App || module.default;
-            const app = new (App.App || App)({ name: "Inventory Dashboard", version: "1.0.0" });
-            app.connect();
-            window.mcpApp = app;
+/* __DASHBOARD_COMMON_JS__ */
 
-            app.onhostcontextchanged = (ctx) => {
-                const theme = ctx?.theme || "light";
-                document.documentElement.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
-            };
-
-            app.ontoolresult = (result) => {
-                const sc = result.structuredContent;
-                if (sc && sc.query) {
-                    fetchHostData(sc.query);
-                }
-            };
-        }).catch(err => {
-            showError("Failed to load MCP Apps SDK: " + err.message);
-        });
+        connectMcpApp("Inventory Dashboard", "1.0.0", (query) => fetchHostData(query));
 
         let allHosts = [];
         let currentPage = 1;
@@ -268,33 +174,10 @@
             applyFiltersAndRender();
         }
 
-        function showError(msg) {
-            const el = document.getElementById("alert");
-            el.textContent = msg;
-            el.classList.remove("hidden");
-        }
-
-        function hideError() {
-            document.getElementById("alert").classList.add("hidden");
-        }
-
         function showView(id) {
             ["view-list", "view-detail", "view-cves", "view-cve-detail", "view-profile"].forEach(v => {
                 document.getElementById(v).classList.toggle("hidden", v !== id);
             });
-        }
-
-        async function callTool(name, args) {
-            if (!window.mcpApp) { showError("MCP App not connected"); return null; }
-            try {
-                const result = await window.mcpApp.callServerTool({ name, arguments: args });
-                const text = result.content?.find(c => c.type === "text")?.text;
-                if (!text) { showError("No response from server"); return null; }
-                try { return JSON.parse(text); } catch { showError(text); return null; }
-            } catch (e) {
-                showError(e.message || "Tool call failed");
-                return null;
-            }
         }
 
         async function fetchHostData(query) {
@@ -370,7 +253,7 @@
             container.innerHTML = data.results.map(host => {
                 const staleness = stalenessInfo(host);
                 return `<div class="host-row" onclick="showDetail('${host.id}')">
-                    <div style="display:flex;justify-content:space-between;align-items:center;">
+                    <div class="row-layout">
                         <div>
                             <span class="host-name">${host.display_name || host.fqdn || host.id}</span>
                             <div class="host-meta">${host.fqdn || "No FQDN"}</div>
@@ -385,22 +268,7 @@
             pag.classList.remove("hidden");
             const totalPages = Math.ceil(filteredTotal / currentPerPage);
             document.getElementById("page-info").textContent = `Page ${currentPage} of ${totalPages}`;
-            renderPageButtons(currentPage, totalPages);
-        }
-
-        function renderPageButtons(current, total) {
-            const container = document.getElementById("page-buttons");
-            const show = new Set([1, total, current, current - 1, current + 1]);
-            const sorted = [...show].filter(p => p >= 1 && p <= total).sort((a, b) => a - b);
-            let html = `<button class="btn btn-back" onclick="goToPage(${current - 1})" ${current === 1 ? 'disabled' : ''}>&laquo;</button>`;
-            let prev = 0;
-            for (const p of sorted) {
-                if (prev && p - prev > 1) html += `<span style="font-size:11px;color:#4d4d4d;padding:0 2px;">...</span>`;
-                html += `<button class="btn ${p === current ? 'btn-secondary' : 'btn-back'}" onclick="goToPage(${p})" style="min-width:28px;padding:4px 6px;">${p}</button>`;
-                prev = p;
-            }
-            html += `<button class="btn btn-back" onclick="goToPage(${current + 1})" ${current === total ? 'disabled' : ''}>&raquo;</button>`;
-            container.innerHTML = html;
+            renderPageButtons(currentPage, totalPages, document.getElementById("page-buttons"));
         }
 
         window.goToPage = function(p) {
@@ -434,7 +302,7 @@
                     <span class="detail-label">FQDN</span>
                     <span class="detail-value">${host.fqdn || "N/A"}</span>
                     <span class="detail-label">ID</span>
-                    <span class="detail-value" style="font-size:11px;font-family:monospace;">${host.id}</span>
+                    <span class="detail-value mono-sm">${host.id}</span>
                     <span class="detail-label">Created</span>
                     <span class="detail-value">${new Date(host.created).toLocaleString()}</span>
                     <span class="detail-label">Updated</span>
@@ -442,7 +310,7 @@
                     <span class="detail-label">Reporter</span>
                     <span class="detail-value">${host.reporter || "N/A"}</span>
                 </div>
-                <div style="padding:12px;display:flex;gap:8px;">
+                <div class="card-actions">
                     <button class="btn btn-secondary" onclick="showProfile('${hostId}')">System Profile</button>
                     <button class="btn btn-secondary" onclick="showHostCves('${hostId}')">View CVEs</button>
                 </div>
@@ -498,18 +366,6 @@
 
         // --- Host CVEs ---
 
-        function severityLabel(impact) {
-            if (typeof impact === "string") return impact;
-            const map = { 7: "Critical", 5: "Important", 4: "Moderate", 2: "Low", 1: "None", 0: "NotSet" };
-            return map[impact] || "Unknown";
-        }
-
-        function severityClass(impact) {
-            const label = (typeof impact === "string" ? impact : severityLabel(impact)).toLowerCase();
-            const map = { critical: "sev-critical", important: "sev-important", moderate: "sev-moderate", low: "sev-low" };
-            return map[label] || "sev-low";
-        }
-
         window.showHostCves = async function(hostId) {
             window.currentHostId = hostId;
             showView("view-cves");
@@ -529,11 +385,11 @@
                 const impact = attrs.impact || 0;
                 const cvss = parseFloat(attrs.cvss3_score) || parseFloat(attrs.cvss2_score) || "N/A";
                 return `<div class="host-row" onclick="showCveDetail('${cve.id}')">
-                    <div style="display:flex;justify-content:space-between;align-items:center;">
-                        <span style="font-weight:600;font-size:13px;font-family:monospace;color:#292929;">${cve.id}</span>
-                        <div style="display:flex;gap:8px;align-items:center;">
-                            <span class="${severityClass(impact)}">${severityLabel(impact)}</span>
-                            <span style="font-family:monospace;font-size:11px;font-weight:600;">${cvss}</span>
+                    <div class="row-layout">
+                        <span class="cve-id">${cve.id}</span>
+                        <div class="row-end">
+                            <span class="severity ${severityClass(impact)}">${severityLabel(impact)}</span>
+                            <span class="cvss">${cvss}</span>
                         </div>
                     </div>
                 </div>`;
@@ -562,22 +418,22 @@
 
             document.getElementById("cve-detail-content").innerHTML = `
                 <div style="padding:12px;">
-                    <p style="margin-bottom:12px;font-size:12px;color:#4d4d4d;">${desc}</p>
+                    <p class="desc-text">${desc}</p>
                 </div>
                 <div class="detail-grid">
                     <span class="detail-label">Severity</span>
-                    <span class="detail-value"><span class="${severityClass(impact)}">${severityLabel(impact)}</span></span>
+                    <span class="detail-value"><span class="severity ${severityClass(impact)}">${severityLabel(impact)}</span></span>
                     <span class="detail-label">CVSS 3</span>
-                    <span class="detail-value" style="font-family:monospace;font-weight:600;">${cvss3}</span>
+                    <span class="detail-value cvss">${cvss3}</span>
                     <span class="detail-label">CVSS 2</span>
-                    <span class="detail-value" style="font-family:monospace;font-weight:600;">${cvss2}</span>
+                    <span class="detail-value cvss">${cvss2}</span>
                     <span class="detail-label">Published</span>
                     <span class="detail-value">${published}</span>
                     <span class="detail-label">Modified</span>
                     <span class="detail-value">${modified}</span>
                     <span class="detail-label">Red Hat</span>
-                    <span class="detail-value"><a href="${redhatUrl}" target="_blank" style="color:#ee0000;">${redhatUrl}</a></span>
-                    ${advisories.length ? `<span class="detail-label">Advisories</span><span class="detail-value">${advisories.map(a => `<a href="${a}" target="_blank" style="color:#ee0000;">${a.split('/').pop()}</a>`).join(', ')}</span>` : ''}
+                    <span class="detail-value"><a href="${redhatUrl}" target="_blank">${redhatUrl}</a></span>
+                    ${advisories.length ? `<span class="detail-label">Advisories</span><span class="detail-value">${advisories.map(a => `<a href="${a}" target="_blank">${a.split('/').pop()}</a>`).join(', ')}</span>` : ''}
                 </div>
             `;
         }

--- a/src/inventory_mcp/server.py
+++ b/src/inventory_mcp/server.py
@@ -5,8 +5,6 @@ Provides tools to get host inventory data for systems connected to Insights.
 """
 
 import logging
-from importlib import resources
-from pathlib import Path
 from typing import Annotated, Any
 
 from fastmcp import Context
@@ -15,6 +13,7 @@ from fastmcp.tools import ToolResult
 from fastmcp.utilities.logging import get_logger
 from pydantic import Field
 
+from insights_mcp.dashboard_ui import load_dashboard_html
 from insights_mcp.mcp import InsightsMCP
 
 _to_client_logger = get_logger(name="fastmcp.server.context.to_client")
@@ -24,16 +23,11 @@ _to_client_logger.setLevel(level=logging.DEBUG)
 INVENTORY_DASHBOARD_RESOURCE_URI = "ui://inventory-dashboard"
 INVENTORY_DASHBOARD_MOUNTED_URI = "ui://inventory_/inventory-dashboard"
 
-
-def _load_inventory_dashboard_html() -> str:
-    """Load the inventory dashboard HTML."""
-    try:
-        return resources.files("inventory_mcp").joinpath("inventory_dashboard.html").read_text(encoding="utf-8")
-    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
-        return (Path(__file__).parent / "inventory_dashboard.html").read_text(encoding="utf-8")
-
-
-EMBEDDED_INVENTORY_DASHBOARD_HTML = _load_inventory_dashboard_html()
+EMBEDDED_INVENTORY_DASHBOARD_HTML = load_dashboard_html(
+    "inventory_mcp",
+    "inventory_dashboard.html",
+    "inventory_dashboard.css",
+)
 
 # For the API documentation, see:
 # https://github.com/RedHatInsights/insights-host-inventory/tree/master/swagger

--- a/src/vulnerability_mcp/cve_dashboard.css
+++ b/src/vulnerability_mcp/cve_dashboard.css
@@ -1,0 +1,10 @@
+.cve-row { padding: 8px 12px; border-bottom: 1px solid var(--border-light); cursor: pointer; transition: background 0.1s; }
+.cve-row:hover { background: var(--row-hover); }
+.cve-row:last-child { border-bottom: none; }
+.cve-meta { font-size: 11px; color: var(--text-secondary); margin-top: 2px; }
+.system-row { padding: 6px 12px; border-bottom: 1px solid var(--border-light); font-size: 12px; }
+.system-row:last-child { border-bottom: none; }
+.system-name { font-weight: 600; color: var(--text-primary); }
+.system-meta { font-size: 11px; color: var(--text-secondary); }
+.playbook-banner { background: #fce3e3; border: 1px solid #ee0000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; display: flex; justify-content: space-between; align-items: center; }
+.playbook-content { background: var(--header-bg); color: #e0e0e0; padding: 12px; border-radius: 4px; font-family: var(--pf-v5-global--FontFamily--monospace); font-size: 11px; white-space: pre-wrap; overflow-x: auto; max-height: 300px; overflow-y: auto; }

--- a/src/vulnerability_mcp/cve_dashboard.html
+++ b/src/vulnerability_mcp/cve_dashboard.html
@@ -6,122 +6,13 @@
     <title>CVE Dashboard</title>
     <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@5.4.2/patternfly.min.css">
     <style>
-        :root {
-            --bg-primary: #ffffff;
-            --bg-secondary: #f2f2f2;
-            --text-primary: #292929;
-            --text-secondary: #4d4d4d;
-            --border-color: #a3a3a3;
-            --border-light: #e0e0e0;
-            --header-bg: #292929;
-            --header-text: #ffffff;
-            --header-meta: #a3a3a3;
-            --row-hover: #f2f2f2;
-            --btn-bg: #e0e0e0;
-            --btn-text: #292929;
-            --input-bg: #ffffff;
-            --input-border: #a3a3a3;
-            --filter-bg: #ffffff;
-            --filter-text: #4d4d4d;
-            --filter-active-bg: #292929;
-            --filter-active-text: #ffffff;
-        }
-        [data-theme="dark"] {
-            --bg-primary: #1a1a1a;
-            --bg-secondary: #2a2a2a;
-            --text-primary: #e0e0e0;
-            --text-secondary: #a3a3a3;
-            --border-color: #4d4d4d;
-            --border-light: #333333;
-            --header-bg: #111111;
-            --header-text: #ffffff;
-            --header-meta: #a3a3a3;
-            --row-hover: #333333;
-            --btn-bg: #333333;
-            --btn-text: #e0e0e0;
-            --input-bg: #2a2a2a;
-            --input-border: #4d4d4d;
-            --filter-bg: #2a2a2a;
-            --filter-text: #a3a3a3;
-            --filter-active-bg: #e0e0e0;
-            --filter-active-text: #1a1a1a;
-        }
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: var(--pf-v5-global--FontFamily--text); font-size: 13px; padding: 12px; background: transparent; color: var(--text-primary); min-height: 100vh; }
-        .header { background: var(--header-bg); color: var(--header-text); padding: 8px 12px; border-radius: 6px; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; }
-        .header-title { font-size: 14px; font-weight: 600; }
-        .header-meta { font-size: 11px; color: var(--header-meta); }
-        .card { background: var(--bg-primary); border-radius: 6px; border: 1px solid var(--border-color); margin-bottom: 12px; overflow: hidden; }
-        .card-title { padding: 8px 12px; border-bottom: 1px solid var(--border-light); font-weight: 600; font-size: 13px; display: flex; align-items: center; gap: 8px; }
-        .card-body { padding: 0; }
-
-        /* Alert banner */
-        .alert-danger { background: #fce3e3; border: 1px solid #a60000; color: #a60000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; }
-
-        /* CVE list */
-        .cve-row { padding: 8px 12px; border-bottom: 1px solid var(--border-light); cursor: pointer; transition: background 0.1s; }
-        .cve-row:hover { background: var(--row-hover); }
-        .cve-row:last-child { border-bottom: none; }
-        .cve-id { font-weight: 600; font-size: 13px; color: var(--text-primary); font-family: var(--pf-v5-global--FontFamily--monospace); }
-        .cve-meta { font-size: 11px; color: var(--text-secondary); margin-top: 2px; }
-
-        /* Severity badges */
-        .severity { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; color: #ffffff; }
-        .severity-critical { background: #a60000; }
-        .severity-important { background: #ca6c0f; }
-        .severity-moderate { background: #dca614; color: #292929; }
-        .severity-low { background: #a3a3a3; }
-        .severity-none { background: #e0e0e0; color: #4d4d4d; }
-
-        /* CVSS score */
-        .cvss { font-family: var(--pf-v5-global--FontFamily--monospace); font-size: 11px; font-weight: 600; }
-
-        /* Detail view */
-        .detail-grid { display: grid; grid-template-columns: 120px 1fr; gap: 4px 12px; padding: 12px; font-size: 12px; }
-        .detail-label { color: var(--text-secondary); font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: 0.5px; }
-        .detail-value { color: var(--text-primary); word-break: break-word; }
-
-        /* Systems list */
-        .system-row { padding: 6px 12px; border-bottom: 1px solid var(--border-light); font-size: 12px; }
-        .system-row:last-child { border-bottom: none; }
-        .system-name { font-weight: 600; color: var(--text-primary); }
-        .system-meta { font-size: 11px; color: var(--text-secondary); }
-
-        /* Buttons */
-        .btn { padding: 4px 12px; border: none; border-radius: 4px; font-size: 12px; font-weight: 600; cursor: pointer; transition: opacity 0.1s; }
-        .btn:hover { opacity: 0.85; }
-        .btn-back { background: var(--btn-bg); color: var(--btn-text); }
-        .btn-primary { background: #ee0000; color: #ffffff; }
-        .btn-secondary { background: var(--header-bg); color: #ffffff; }
-        .btn:disabled { opacity: 0.5; cursor: not-allowed; }
-
-        /* Pagination */
-        .pagination { padding: 8px 12px; display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--text-secondary); border-top: 1px solid var(--border-light); }
-
-        /* Loading */
-        .loading { text-align: center; padding: 24px; color: var(--text-secondary); font-size: 12px; }
-
-        /* Playbook */
-        .playbook-banner { background: #fce3e3; border: 1px solid #ee0000; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; display: flex; justify-content: space-between; align-items: center; }
-        .playbook-content { background: var(--header-bg); color: #e0e0e0; padding: 12px; border-radius: 4px; font-family: var(--pf-v5-global--FontFamily--monospace); font-size: 11px; white-space: pre-wrap; overflow-x: auto; max-height: 300px; overflow-y: auto; }
-
-        /* Filters */
-        .filters { padding: 8px 12px; border-bottom: 1px solid var(--border-light); display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
-        .filter-btn { padding: 2px 8px; border: 1px solid var(--border-color); border-radius: 12px; font-size: 11px; cursor: pointer; background: var(--filter-bg); color: var(--filter-text); transition: all 0.1s; }
-        .filter-btn.active { background: var(--filter-active-bg); color: var(--filter-active-text); border-color: var(--filter-active-bg); }
-        .filter-btn:hover { border-color: var(--text-primary); }
-
-        /* Links */
-        a { color: #ee0000; text-decoration: none; }
-        a:hover { text-decoration: underline; }
-
-        /* Hidden */
-        .hidden { display: none !important; }
+/* __DASHBOARD_BASE_CSS__ */
+/* __DASHBOARD_EXTRA_CSS__ */
     </style>
 </head>
 <body>
     <div class="header">
-        <span class="header-title"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAdnJLH8AAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+kHHQcvBP3yWUkAAASbSURBVGje7dl5iFVVHAfwz5k3Y+OS5jNN29Boo73Esn0RKouIVtqJVuwPkQiigooWKdIsqKiICoMKIioKyRawohXbixYyKiTavNrY4ujMO/1xjvEcxnlvxvfGgvnCgffuPffc3/ec334ZwhCG8L9GaObiBSMxFh1YXSb+ZwgUbIuTMREf4rUyK6vu74ZbMRU/4V28gvfwa6PIhAEKPxEPY2a+1JkFeyKT2RFXYVqPR9fgK7yIZ/FROV0bdALX4ZZeblXwF4bl0RdW4jU8hlfL/D4oBPLuL8Y+DVLjNXgb92FROW1A3WgZwAunS/rdKLTjaCzEAwVTmkagSPNPxBZNcFrDcR7uKRjXrBPYAUc12bUfi+OaReBw/TziAaAVRzScQJEWPgGlQQiw+xaMbvQJ7IRDBylDmJLVtXEEvuWoWOeiDcA47NFIAiNv57TVhDA4BFpxQL0Te+p6wJaYgAkjGHs9e93N9P0xK0e/2HwS+xe010o1WqsEH4XDsp+fhu0xppMthtPSSekOjCaeTWhpPoldc6L4XU0CBXvhpux/R1RPiPgly7oS1xJ+JV6GUYTu5hGYiF1qEWjJae9DOKWn8OuTpWrH34G5hNn4glhqXlExvLMOO2jBbBy0sQkRM7Bzlcasw9OEc3A/sWgSkU9TLdHa15zS1SzQR+4R080wAksI6zbMh8MSwts5uk3KatUI++jGI5S2ZvHXrOjrBMbUWiziTMIcYnuPe12p1AqzCWdgAfEz4tq8df09mZCfe4e4iF1m8eSfXFFQ7nV+wSfYu56F1+JB4nzCqj7mjSdOzQnNVEzGVoRhNQJPd3Io8SXMT8EzPEw8le4uluBGvFVdjoaCebiyno0KueRaTJyLz2o8E5JKxe1yHjIl+ea4dbqulPn8TeVnwldYii8JnXmNO+m+hFJX+rsc1+DxchKFIiVO3xTZGOsZvxM/pjKLyri0UOzPCMRWYlsepY3MG0Z8gkrHhu8vCi7YoKQskieah7b+pLFdeJ/4KF7CigY7okOIC7MT6eEUfsRZZd4IVVH4LlzUX29YyrbxKfE5vIxlVSowUOxJXIADCZXepyzCuaEqlZiAe3HaQFx6KdvHL8QPcrthaQ6jqwhddZ7qJOJMXJ7C8MaEhz9xceiRyG2D23Jt2jrQNkcpe5QO4vJ0IpYRf0gEQwdxTVKL0EZlLGHH3OaYlgw+rN+QGlgYeslGR2evNKeeGFGLTEvVcXZnu1lH7MqXS8mQ/3WxlfoEX483Qx/l40m4Afs2uym7CVH79V7jSpmuMs/kBO+epMaNRbW/3AQsC3UU8204MqvUjNyI+i9gDS4N/ehKjMrN3Mty4bO5ibyB0wfSGx2NY3B+bgmO3QzCF7iwzPOb8n2gHfvh1Hwyu6rdkW4EVkrd8QfKVEIDtiJI8WM6js/qtVPudTYSFenbw814oZy8cmNzl9z8HZ/T84NTJmD3XN+OHOD7OlKm4ik8VU550KB9IxuW2zOTs4rtnH9PzLYzMqvd+k7NWvyB3/B9FnwpPt/YB5CwGayvRWrPt+fRVkWgK5UH/kZneVDaT0MYwhA2K/4BI+BgELD+CNsAAAAASUVORK5CYII=" alt="Red Hat" style="height:16px;vertical-align:middle;margin-right:6px;">Red Hat Lightspeed — CVE Dashboard</span>
+        <span class="header-title"><!-- __DASHBOARD_ICON__ -->Red Hat Lightspeed — CVE Dashboard</span>
         <span class="header-meta" id="total-count"></span>
     </div>
 
@@ -133,21 +24,21 @@
             <div class="card-title">
                 <span>Vulnerabilities</span>
             </div>
-            <div style="padding:8px 12px;border-bottom:1px solid #e0e0e0;display:flex;gap:4px;align-items:center;">
-                <input type="text" id="search-input" placeholder="Search CVEs (e.g., CVE-2026-3497 or kernel)" style="flex:1;padding:4px 8px;border:1px solid var(--input-border);border-radius:4px;font-size:12px;font-family:inherit;background:var(--input-bg);color:var(--text-primary);" onkeydown="if(event.key==='Enter')searchCves()">
-                <button class="btn btn-secondary" onclick="searchCves()" style="padding:4px 8px;">Search</button>
-                <button class="btn btn-back" onclick="clearSearch()" style="padding:4px 8px;">Clear</button>
+            <div class="search-bar">
+                <input type="text" id="search-input" placeholder="Search CVEs (e.g., CVE-2026-3497 or kernel)" onkeydown="if(event.key==='Enter')searchCves()">
+                <button class="btn btn-sm btn-secondary" onclick="searchCves()">Search</button>
+                <button class="btn btn-sm btn-back" onclick="clearSearch()">Clear</button>
             </div>
             <div class="filters" id="filters">
-                <span style="font-size:11px;color:#4d4d4d;">Severity:</span>
+                <span class="filter-label">Severity:</span>
                 <button class="filter-btn active" data-impact="all" onclick="filterImpact(this)">All</button>
                 <button class="filter-btn" data-impact="critical" onclick="filterImpact(this)">Critical</button>
                 <button class="filter-btn" data-impact="important" onclick="filterImpact(this)">Important</button>
                 <button class="filter-btn" data-impact="moderate" onclick="filterImpact(this)">Moderate</button>
                 <button class="filter-btn" data-impact="low" onclick="filterImpact(this)">Low</button>
-                <span style="margin-left:8px;border-left:1px solid #a3a3a3;padding-left:8px;">
-                    <label style="font-size:11px;color:#4d4d4d;">Sort:
-                        <select id="sort-select" onchange="changeSort(this.value)" style="font-size:11px;border:1px solid #a3a3a3;border-radius:4px;padding:1px 4px;font-family:inherit;">
+                <span class="filter-divider">
+                    <label class="filter-label">Sort:
+                        <select id="sort-select" onchange="changeSort(this.value)" class="select">
                             <option value="-systems_affected">Most affected</option>
                             <option value="-cvss_score">CVSS (highest)</option>
                             <option value="cvss_score">CVSS (lowest)</option>
@@ -164,7 +55,7 @@
             </div>
             <div class="pagination hidden" id="pagination">
                 <span id="page-info"></span>
-                <div id="page-buttons" style="display:flex;gap:2px;align-items:center;flex-wrap:wrap;"></div>
+                <div id="page-buttons" class="page-buttons"></div>
             </div>
         </div>
     </div>
@@ -209,26 +100,9 @@
     </div>
 
     <script type="module">
-        import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
-            const App = module.App || module.default?.App || module.default;
-            const app = new (App.App || App)({ name: "CVE Dashboard", version: "1.0.0" });
-            app.connect();
-            window.mcpApp = app;
+/* __DASHBOARD_COMMON_JS__ */
 
-            app.onhostcontextchanged = (ctx) => {
-                const theme = ctx?.theme || "light";
-                document.documentElement.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
-            };
-
-            app.ontoolresult = (result) => {
-                const sc = result.structuredContent;
-                if (sc && sc.query) {
-                    fetchCveData(sc.query);
-                }
-            };
-        }).catch(err => {
-            showError("Failed to load MCP Apps SDK: " + err.message);
-        });
+        connectMcpApp("CVE Dashboard", "1.0.0", (query) => fetchCveData(query));
 
         let allCves = [];
         let currentPage = 1;
@@ -297,38 +171,10 @@
             applyFiltersAndRender();
         }
 
-        function showError(msg) {
-            const el = document.getElementById("alert");
-            el.textContent = msg;
-            el.classList.remove("hidden");
-        }
-
-        function hideError() {
-            document.getElementById("alert").classList.add("hidden");
-        }
-
         function showView(id) {
             ["view-list", "view-detail", "view-systems", "view-playbook"].forEach(v => {
                 document.getElementById(v).classList.toggle("hidden", v !== id);
             });
-        }
-
-        async function callTool(name, args) {
-            if (!window.mcpApp) { showError("MCP App not connected"); return null; }
-            try {
-                const result = await window.mcpApp.callServerTool({ name, arguments: args });
-                const text = result.content?.find(c => c.type === "text")?.text;
-                if (!text) { showError("No response from server"); return null; }
-                try {
-                    return JSON.parse(text);
-                } catch {
-                    showError(text);
-                    return null;
-                }
-            } catch (e) {
-                showError(e.message || "Tool call failed");
-                return null;
-            }
         }
 
         async function fetchCveData(query) {
@@ -383,18 +229,6 @@
             applyFiltersAndRender();
         }
 
-        function severityLabel(impact) {
-            if (typeof impact === "string") return impact;
-            const map = { 7: "Critical", 5: "Important", 4: "Moderate", 2: "Low", 1: "None", 0: "NotSet" };
-            return map[impact] || "Unknown";
-        }
-
-        function severityClass(impact) {
-            const label = (typeof impact === "string" ? impact : severityLabel(impact)).toLowerCase();
-            const map = { critical: "severity-critical", important: "severity-important", moderate: "severity-moderate", low: "severity-low", none: "severity-none", notset: "severity-none" };
-            return map[label] || "severity-none";
-        }
-
         // --- CVE List ---
 
         function renderCveList(data) {
@@ -414,9 +248,9 @@
                 const cvss = parseFloat(attrs.cvss3_score) || parseFloat(attrs.cvss2_score) || "N/A";
                 const systems = attrs.systems_affected || 0;
                 return `<div class="cve-row" onclick="showDetail('${cve.id}')">
-                    <div style="display:flex;justify-content:space-between;align-items:center;">
+                    <div class="row-layout">
                         <span class="cve-id">${cve.id}</span>
-                        <div style="display:flex;gap:8px;align-items:center;">
+                        <div class="row-end">
                             <span class="severity ${severityClass(impact)}">${severityLabel(impact)}</span>
                             <span class="cvss">${cvss}</span>
                         </div>
@@ -430,30 +264,7 @@
             pag.classList.remove("hidden");
             const totalPages = Math.ceil(filteredTotal / currentLimit);
             document.getElementById("page-info").textContent = `Page ${currentPage} of ${totalPages}`;
-            renderPageButtons(currentPage, totalPages);
-        }
-
-        function renderPageButtons(current, total) {
-            const container = document.getElementById("page-buttons");
-            let pages = [];
-
-            // Always show first, last, current, and neighbors
-            const show = new Set([1, total, current, current - 1, current + 1]);
-            // Add a couple more around current for context
-            if (current > 3) show.add(current - 2);
-            if (current < total - 2) show.add(current + 2);
-
-            const sorted = [...show].filter(p => p >= 1 && p <= total).sort((a, b) => a - b);
-
-            let html = `<button class="btn btn-back" onclick="goToPage(${current - 1})" ${current === 1 ? 'disabled' : ''}>&laquo;</button>`;
-            let prev = 0;
-            for (const p of sorted) {
-                if (prev && p - prev > 1) html += `<span style="font-size:11px;color:#4d4d4d;padding:0 2px;">...</span>`;
-                html += `<button class="btn ${p === current ? 'btn-secondary' : 'btn-back'}" onclick="goToPage(${p})" style="min-width:28px;padding:4px 6px;">${p}</button>`;
-                prev = p;
-            }
-            html += `<button class="btn btn-back" onclick="goToPage(${current + 1})" ${current === total ? 'disabled' : ''}>&raquo;</button>`;
-            container.innerHTML = html;
+            renderPageButtons(currentPage, totalPages, document.getElementById("page-buttons"));
         }
 
         window.goToPage = function(p) {
@@ -492,7 +303,7 @@
 
             document.getElementById("cve-detail").innerHTML = `
                 <div style="padding:12px;">
-                    <p style="margin-bottom:12px;font-size:12px;color:#4d4d4d;">${desc}</p>
+                    <p class="desc-text">${desc}</p>
                 </div>
                 <div class="detail-grid">
                     <span class="detail-label">Severity</span>
@@ -509,7 +320,7 @@
                     <span class="detail-value"><a href="${redhatUrl}" target="_blank">${redhatUrl}</a></span>
                     ${advisories.length ? `<span class="detail-label">Advisories</span><span class="detail-value">${advisories.map(a => `<a href="${a}" target="_blank">${a.split('/').pop()}</a>`).join(', ')}</span>` : ''}
                 </div>
-                <div style="padding:12px;display:flex;gap:8px;">
+                <div class="card-actions">
                     <button class="btn btn-secondary" onclick="showSystems('${cveId}')">View Affected Systems</button>
                 </div>
             `;
@@ -536,8 +347,7 @@
                 return;
             }
 
-            // Separate affected from non-affected systems
-            // status_text can be null (meaning affected, no status set), or strings like "Not affected", "Patched"
+            // status_text can be null (affected), "Not affected", or "Patched"
             const systems = data.data.map(sys => {
                 const attrs = sys.attributes || {};
                 const status = (attrs.status_text || "").toLowerCase();
@@ -559,7 +369,7 @@
                     const os = sys.attrs.os || "Unknown OS";
                     const status = sys.attrs.status_text || sys.attrs.status || "";
                     return `<div class="system-row">
-                        <div style="display:flex;justify-content:space-between;align-items:center;">
+                        <div class="row-layout">
                             <div>
                                 <label style="cursor:pointer;">
                                     <input type="checkbox" value="${sys.id}" onchange="toggleSystem(this)" style="margin-right:6px;">
@@ -570,7 +380,7 @@
                         </div>
                     </div>`;
                 }).join("")}
-                ${affectedSystems.length > 0 ? `<div style="padding:12px;">
+                ${affectedSystems.length > 0 ? `<div class="card-actions">
                     <button class="btn btn-primary" id="btn-remediate" onclick="remediate('${cveId}')" disabled>Remediate Selected</button>
                 </div>` : ''}
             `;
@@ -653,12 +463,6 @@
                 const btn = document.querySelector('[onclick="copyPlaybook()"]');
                 if (btn) { btn.textContent = "Copied!"; setTimeout(() => btn.textContent = "Copy to clipboard", 2000); }
             }
-        }
-
-        function escapeHtml(str) {
-            const div = document.createElement("div");
-            div.textContent = str;
-            return div.innerHTML;
         }
     </script>
 </body>

--- a/src/vulnerability_mcp/server.py
+++ b/src/vulnerability_mcp/server.py
@@ -7,8 +7,6 @@ Provides CVE analysis, system mapping, and remediation guidance.
 import logging
 import uuid
 from enum import Enum
-from importlib import resources
-from pathlib import Path
 from typing import Annotated, Any
 
 from fastmcp import Context
@@ -17,6 +15,7 @@ from fastmcp.tools import ToolResult
 from fastmcp.utilities.logging import get_logger
 from pydantic import Field
 
+from insights_mcp.dashboard_ui import load_dashboard_html
 from insights_mcp.mcp import InsightsMCP
 
 _to_client_logger = get_logger(name="fastmcp.server.context.to_client")
@@ -26,16 +25,11 @@ _to_client_logger.setLevel(level=logging.DEBUG)
 CVE_DASHBOARD_RESOURCE_URI = "ui://cve-dashboard"
 CVE_DASHBOARD_MOUNTED_URI = "ui://vulnerability_/cve-dashboard"
 
-
-def _load_cve_dashboard_html() -> str:
-    """Load the CVE dashboard HTML."""
-    try:
-        return resources.files("vulnerability_mcp").joinpath("cve_dashboard.html").read_text(encoding="utf-8")
-    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
-        return (Path(__file__).parent / "cve_dashboard.html").read_text(encoding="utf-8")
-
-
-EMBEDDED_CVE_DASHBOARD_HTML = _load_cve_dashboard_html()
+EMBEDDED_CVE_DASHBOARD_HTML = load_dashboard_html(
+    "vulnerability_mcp",
+    "cve_dashboard.html",
+    "cve_dashboard.css",
+)
 
 
 class CVETypes(Enum):

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -1,0 +1,125 @@
+"""Tests for dashboard UI composition utilities."""
+
+import importlib
+import re
+
+import pytest
+
+from insights_mcp.dashboard_ui import (
+    compose_dashboard_html,
+    get_icon_img_tag,
+    load_dashboard_html,
+)
+
+_TEMPLATE = (
+    "<style>/* __DASHBOARD_BASE_CSS__ */\n/* __DASHBOARD_EXTRA_CSS__ */</style>"
+    "<script>/* __DASHBOARD_COMMON_JS__ */</script>"
+    "<span><!-- __DASHBOARD_ICON__ -->Title</span>"
+)
+
+
+def test_compose_replaces_all_placeholders() -> None:
+    """Verify all four placeholders are replaced in a single pass."""
+    result = compose_dashboard_html(
+        _TEMPLATE,
+        base_css="body { color: red; }",
+        extra_css=".custom { margin: 0; }",
+        common_js="function test() {}",
+    )
+    assert "body { color: red; }" in result
+    assert ".custom { margin: 0; }" in result
+    assert "function test() {}" in result
+    assert '<img src="data:image/png;base64,' in result
+    for placeholder in (
+        "__DASHBOARD_BASE_CSS__",
+        "__DASHBOARD_EXTRA_CSS__",
+        "__DASHBOARD_COMMON_JS__",
+        "__DASHBOARD_ICON__",
+    ):
+        assert placeholder not in result
+
+
+def test_get_icon_img_tag_returns_img_element() -> None:
+    """Verify get_icon_img_tag returns a valid img tag."""
+    tag = get_icon_img_tag()
+    assert tag.startswith('<img src="data:image/png;base64,')
+    assert 'alt="Red Hat"' in tag
+    assert tag.endswith('">')
+
+
+@pytest.mark.parametrize(
+    ("package", "template", "css", "marker"),
+    [
+        ("vulnerability_mcp", "cve_dashboard.html", "cve_dashboard.css", ".cve-row"),
+        ("inventory_mcp", "inventory_dashboard.html", "inventory_dashboard.css", ".host-row"),
+    ],
+    ids=["cve", "inventory"],
+)
+def test_load_dashboard_html_produces_complete_html(package: str, template: str, css: str, marker: str) -> None:
+    """Verify dashboard composition replaces all placeholders and includes expected content."""
+    html = load_dashboard_html(package, template, css)
+    assert "<!DOCTYPE html>" in html
+    for placeholder in (
+        "__DASHBOARD_BASE_CSS__",
+        "__DASHBOARD_EXTRA_CSS__",
+        "__DASHBOARD_COMMON_JS__",
+        "__DASHBOARD_ICON__",
+    ):
+        assert placeholder not in html
+    assert "function callTool" in html
+    assert marker in html
+    assert '<img src="data:image/png;base64,' in html
+
+
+@pytest.mark.parametrize(
+    ("module_path", "attr", "package", "template", "css"),
+    [
+        (
+            "vulnerability_mcp.server",
+            "EMBEDDED_CVE_DASHBOARD_HTML",
+            "vulnerability_mcp",
+            "cve_dashboard.html",
+            "cve_dashboard.css",
+        ),
+        (
+            "inventory_mcp.server",
+            "EMBEDDED_INVENTORY_DASHBOARD_HTML",
+            "inventory_mcp",
+            "inventory_dashboard.html",
+            "inventory_dashboard.css",
+        ),
+    ],
+    ids=["cve", "inventory"],
+)
+def test_server_embedded_html_matches_load(module_path: str, attr: str, package: str, template: str, css: str) -> None:
+    """Server module-level constants must match what load_dashboard_html produces."""
+    module = importlib.import_module(module_path)
+    expected = load_dashboard_html(package, template, css)
+    assert getattr(module, attr) == expected
+
+
+# Theme colors that must only appear inside CSS custom property definitions,
+# never in inline style attributes or JS-generated HTML.
+_THEME_COLORS = {"#4d4d4d", "#a3a3a3", "#292929", "#e0e0e0", "#333333", "#1a1a1a", "#2a2a2a"}
+
+_STYLE_ATTR_RE = re.compile(r'style="([^"]*)"')
+
+
+@pytest.mark.parametrize(
+    ("package", "template", "css"),
+    [
+        ("vulnerability_mcp", "cve_dashboard.html", "cve_dashboard.css"),
+        ("inventory_mcp", "inventory_dashboard.html", "inventory_dashboard.css"),
+    ],
+    ids=["cve", "inventory"],
+)
+def test_no_theme_colors_in_inline_styles(package: str, template: str, css: str) -> None:
+    """Theme-dependent colors must use CSS variables, not hardcoded hex in inline styles."""
+    html = load_dashboard_html(package, template, css)
+    violations = []
+    for match in _STYLE_ATTR_RE.finditer(html):
+        style_value = match.group(1).lower()
+        for color in _THEME_COLORS:
+            if color in style_value:
+                violations.append(f'{color} found in: style="{style_value}"')
+    assert not violations, "Hardcoded theme colors in inline styles:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary

- Extract duplicated CSS and JS from CVE and inventory dashboards into shared assets under `src/insights_mcp/assets/`
- HTML templates use placeholder comments (`__DASHBOARD_BASE_CSS__`, `__DASHBOARD_COMMON_JS__`, etc.) replaced at load time by `dashboard_ui.py`, producing self-contained HTML for MCP Apps
- Dashboard-specific styles live in `.css` files alongside each toolset
- Updated HACKING.md "Adding a New MCP App" guide to reflect the new shared asset architecture
- Added tests for composition logic, server wiring, and a regression guard against hardcoded theme colors

New dashboards can now reuse the shared base by creating an HTML template + CSS file and calling `load_dashboard_html()`.

Supersedes #392 — implements the same idea (proposed by @schuellerf) on top of current main after #389 was merged.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] Both dashboards tested via stdio in Cursor with all 6 test prompts from `test_prompts.md`
- [x] Wheel build includes all CSS/JS/HTML assets