### PR TITLE
list_repositories response trimming

### DIFF
--- a/src/content_sources_mcp/server.py
+++ b/src/content_sources_mcp/server.py
@@ -75,7 +75,18 @@ class ContentSourcesMCP(InsightsMCP):
     async def list_repositories(
         self,
         enabled: Annotated[Optional[bool], Field(default=None, description="Filter by enabled status (True/False).")],
-        limit: Annotated[int, Field(default=10, description="Maximum number of repositories to return (default: 10).")],
+        limit: Annotated[
+            int,
+            Field(
+                default=10,
+                description=(
+                    "Maximum number of repositories to return (default: 10, maximum: 100). "
+                    "**ALWAYS use the default value of 10 for the first call.** "
+                    "This default is carefully chosen for performance and context management. "
+                    "Only increase this value if the user explicitly asks to see more repositories at once."
+                ),
+            ),
+        ],
         offset: Annotated[
             int, Field(default=0, description="Number of repositories to skip for pagination (default: 0).")
         ],
@@ -112,7 +123,7 @@ class ContentSourcesMCP(InsightsMCP):
         if version:
             params["version"] = version
 
-        params["limit"] = limit
+        params["limit"] = min(limit, 100)
         params["offset"] = offset
 
         def _strip_gpg_keys(response: dict[str, Any] | str | list[Any]) -> dict[str, Any] | str | list[Any]:

--- a/src/content_sources_mcp/server.py
+++ b/src/content_sources_mcp/server.py
@@ -85,6 +85,9 @@ class ContentSourcesMCP(InsightsMCP):
         origin: Annotated[str, Field(default="", description="Filter by origin (e.g., 'red_hat', 'external').")],
         arch: Annotated[str, Field(default="", description="Filter by architecture (e.g., 'x86_64', 'aarch64').")],
         version: Annotated[str, Field(default="", description="Filter by version (e.g., '8', '9').")],
+        include_gpg_key: Annotated[
+            bool, Field(default=False, description="Include GPG key content in the response (default: False).")
+        ],
     ) -> str:
         """List repositories with filtering and pagination options.
 
@@ -112,9 +115,16 @@ class ContentSourcesMCP(InsightsMCP):
         params["limit"] = limit
         params["offset"] = offset
 
+        def _strip_gpg_keys(response: dict[str, Any] | str | list[Any]) -> dict[str, Any] | str | list[Any]:
+            if isinstance(response, dict) and "data" in response:
+                for repo in response["data"]:
+                    repo.pop("gpg_key", None)
+            return response
+
         return await run_insights_tool_request(
             self.insights_client.get("repositories/", params=params),
             error_message=lambda exc: f"Error listing repositories: {exc}",
+            response_transform=None if include_gpg_key else _strip_gpg_keys,
         )
 
 

--- a/src/content_sources_mcp/tests/test_mcp_tool_validation.py
+++ b/src/content_sources_mcp/tests/test_mcp_tool_validation.py
@@ -77,6 +77,12 @@ from tests.test_patterns import (
                     "type": "string",
                     "anyOf": None,
                 },
+                "include_gpg_key": {
+                    "description": "Include GPG key content in the response (default: False).",
+                    "default": False,
+                    "type": "boolean",
+                    "anyOf": None,
+                },
             },
         ),
     ],

--- a/src/content_sources_mcp/tests/test_mcp_tool_validation.py
+++ b/src/content_sources_mcp/tests/test_mcp_tool_validation.py
@@ -24,7 +24,12 @@ from tests.test_patterns import (
             "List repositories with filtering and pagination options.",
             {
                 "limit": {
-                    "description": "Maximum number of repositories to return (default: 10).",
+                    "description": (
+                        "Maximum number of repositories to return (default: 10, maximum: 100). "
+                        "**ALWAYS use the default value of 10 for the first call.** "
+                        "This default is carefully chosen for performance and context management. "
+                        "Only increase this value if the user explicitly asks to see more repositories at once."
+                    ),
                     "default": 10,
                     "type": "integer",
                     "anyOf": None,

--- a/src/tools/common.py
+++ b/src/tools/common.py
@@ -178,10 +178,13 @@ async def run_insights_tool_request(
     *,
     error_message: Callable[[Exception], str],
     logger: Logger | None = None,
+    response_transform: Callable[[dict[str, Any] | str | list[Any]], dict[str, Any] | str | list[Any]] | None = None,
 ) -> str:
     """Await an Insights client call, encode JSON, and map failures to InsightsApiError."""
     try:
         response = await request
+        if response_transform is not None:
+            response = response_transform(response)
         return encode_insights_json_response(response)
     except TOOL_REQUEST_ERRORS as exc:
         raise_insights_tool_error(exc, error_message(exc), logger)


### PR DESCRIPTION
## Summary

Reduces LLM context window usage and payload size when querying repository content sources by stripping unnecessary GPG keys by default and enforcing pagination limits.

## Context

While redesigning LLM tests, broad prompts like *"List all repositories from content sources"* frequently overwhelmed the model context window. Standard pagination warnings or hard limits were insufficient on their own, as the model simply compensated by issuing more paginated requests.

Payload investigation revealed that **~80% of the response payload consisted of GPG key data**, which is redundant for the vast majority of model interactions.

## Changes

- **Strip GPG keys by default:** Added an `include_gpg_key` parameter (default `False`) to control whether GPG key content is included in responses.
- **Enforce pagination limit:** Implemented a hard cap of `100` items per request, aligning with the existing `list_hosts` pattern in the inventory toolset.
- **Add response transform hook:** Updated `run_insights_tool_request` with a `response_transform` hook to enable client-side response filtering without altering interfaces for existing callers.