### PR TITLE
insights_mcp: auth error handling (HMS-10083)

### DIFF
--- a/src/insights_mcp/client.py
+++ b/src/insights_mcp/client.py
@@ -227,8 +227,11 @@ class InsightsClientBase(httpx.AsyncClient):
             f"[{self.insights_base_url}/iam/service-accounts]({self.insights_base_url}/iam/service-accounts) "
             "Come up with a detailed description of this for the user. "
             "Only describe this, don't expose details about the tool function itself. "
-            f"Don't proceed with the request before this is fixed. {error_message}"
+            f"Don't proceed with the request before this is fixed. {error_message}\n"
         )
+
+        if isinstance(e, httpx.HTTPStatusError):
+            return_message += f"Response: {e.response.text}"
 
         return return_message
 
@@ -252,7 +255,8 @@ class InsightsClientBase(httpx.AsyncClient):
             "lacks the required permissions to access this resource.\n"
             "Come up with a detailed description of this for the user. "
             "Only describe this, don't expose details about the tool function itself. "
-            f"Don't proceed with the request before this is fixed. Error: {str(e)}."
+            f"Don't proceed with the request before this is fixed. Error: {str(e)}. "
+            f"Response: {e.response.text}"
         )
 
 

--- a/src/insights_mcp/tests/test_errors.py
+++ b/src/insights_mcp/tests/test_errors.py
@@ -1,0 +1,19 @@
+"""Tests for InsightsClientBase error message handling."""
+
+import httpx
+import pytest
+
+from insights_mcp.client import InsightsClientBase
+from insights_mcp.config import INSIGHTS_BASE_URL
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 500])
+def test_response_body_preserved(status_code: int) -> None:
+    """Error message includes the HTTP response body."""
+    body = "detailed and important error from backend"
+    client = InsightsClientBase(base_url=INSIGHTS_BASE_URL)
+    request = httpx.Request("POST", "https://example.com/api/v1/compose")
+    response = httpx.Response(status_code, text=body, request=request)
+    error = httpx.HTTPStatusError("error", request=request, response=response)
+
+    assert body in client.get_error_message(error)


### PR DESCRIPTION
This PR adds API error messages in the instructions for the model.
The motivation is the API sending 403 error with a hint for the required roles, which now gets lost (replaced with '403 Forbidden') by the insights_mcp client and never reaches the model or the user.

Example of model's behavior after this change:
```
The compose failed with a 403 Forbidden — you're authenticated but missing the required 
permissions to trigger a build.

Specifically, the API says you need "Repositories viewer" or "Content Template viewer" permissions. 
You can check and request the right access at:

 IAM User Access Overview

You (or an org administrator) will need to grant those permissions before a compose can be kicked off. 
Want me to check your current RBAC permissions to see what you have?
``` 