### PR TITLE
fix: reword dashboard test prompts to reliably trigger MCP Apps tools

### DIFF
--- a/src/inventory_mcp/test_prompts.md
+++ b/src/inventory_mcp/test_prompts.md
@@ -10,4 +10,4 @@
 - Show me all enabled repositories on host `XXX`
 - Find hosts with more than 16GB of memory running on AWS
 - Open the inventory dashboard
-- Show me my fleet
+- Show my fleet in the inventory dashboard

--- a/src/vulnerability_mcp/test_prompts.md
+++ b/src/vulnerability_mcp/test_prompts.md
@@ -5,6 +5,6 @@
 - Explain why `CVE-XXXX-XXXX` affects system `YYY`
 - What CVEs are affecting system XXX because of outdated kernel package
 - Open the CVE dashboard for my account
-- Show me all CVEs affecting my account
-- Open the CVE dashboard for system `XXX`
+- Show me critical CVEs in the dashboard
+- Show the CVE dashboard for system `XXX`
 - Open the CVE dashboard for system `XXX` with remediatable CVEs only


### PR DESCRIPTION
## Summary

- Reword 3 dashboard test prompts that occasionally failed to trigger the dashboard tools:
  - "Show me all CVEs affecting my account" → ["Show me critical CVEs in the dashboard"](https://drive.google.com/file/d/1f8KcfivJR01OeVoJDNCLAjUbOCpUl8n9/view?usp=drive_link)
  - "Show me my fleet" → ["Show my fleet in the inventory dashboard"](https://drive.google.com/file/d/1V7fPuvTJhWRh0NoXtz1d4tQq-7m07moy/view?usp=drive_link)
  - "Open the CVE dashboard for system XXX" → ["Show the CVE dashboard for system XXX"](https://drive.google.com/file/d/1xLURSAwWL7AlmChHapD34wY-gT9e41cm/view?usp=drive_link)
- Verified unchanged prompts still work:
  - ["Open the CVE dashboard for my account"](https://drive.google.com/file/d/1wcTUomnQz5ow8uKH0C1cc0-clxUTTSoU/view?usp=drive_link)
  - ["Open the inventory dashboard"](https://drive.google.com/file/d/1ExoEazAAG5dhLUXiGesJ5kBCyP7_KpLa/view?usp=drive_link)
  - ["Open the CVE dashboard for system XXX with remediatable CVEs only"](https://drive.google.com/file/d/1g4xUrc7bdZXuyVBk-s1L9uDOhrb77s21/view?usp=drive_link)

> **Note:** The 3rd recording shows a Cursor Canvas being generated after the dashboard loads. This is an unrelated Cursor client issue being investigated in [APPENG-5838](https://redhat.atlassian.net/browse/APPENG-5838) and does not affect this PR.

## Test plan

- [x] All 6 dashboard prompts tested in Cursor via stdio
- [x] `make lint` passes
- [x] `make test` passes

[APPENG-5838]: https://redhat.atlassian.net/browse/APPENG-5838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ