### PR TITLE
feat(RHIN-2762, RHIN-2764): implement lola package manager and getting-started skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,547 @@
+# Red Hat Lightspeed MCP
+_(formerly known as Insights MCP)_
+
+Red Hat Lightspeed Model Context Protocol ([MCP](https://modelcontextprotocol.io)) server is a lightweight, self-hosted solution that connects LLM-based agents - such as Claude Desktop and other MCP-compatible tools - to Red Hat Lightspeed services.
+
+## Features
+ * Supports read-only operations: The server runs in read-only mode by default. Use `--all-tools` to enable write tools (e.g. create blueprints, run composes). RBAC permissions can also restrict access.
+ * Provides natural language prompts: provides an ability to use natural language for querying Red Hat Lightspeed services
+
+## Supported Lightspeed Services
+ * [advisor](https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/assessing_rhel_configuration_issues_using_the_red_hat_insights_advisor_service/index)
+ * [hosted image builder](https://osbuild.org/docs/hosted/architecture/)
+ * [inventory](https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/viewing_and_managing_system_inventory/index)
+ * [planning](https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/dynamically_creating_a_digital_roadmap_to_manage_rhel_systems/index)
+ * [remediations](https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/red_hat_insights_remediations_guide/index)
+ * [vulnerability](https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/assessing_and_monitoring_security_vulnerabilities_on_rhel_systems/index)
+
+## Setup and usage
+
+### Authentication
+
+**Note**: Authentication is only required for accessing Red Hat Lightspeed APIs. The MCP server itself does not require authentication.
+
+There are two ways to authenticate:
+
+1. **Service Account** (client_id + client_secret) — create a service account and provide the credentials via environment variables or HTTP headers.
+2. **JWT Bearer Token** — provide a pre-existing JWT token via the `Authorization: Bearer <token>` HTTP header (SSE/HTTP transports only).
+
+#### Service Account Setup
+
+1. Go to https://console.redhat.com → Click Settings (⚙️ Gear Icon) →  "Service Accounts"
+2. Create a service account and remember `Client ID` and `Client secret` for later.<br>
+   See below in the integration instructions, there they are respectively referred to as
+   `LIGHTSPEED_CLIENT_ID` and `LIGHTSPEED_CLIENT_SECRET`.
+
+#### Required Permissions by Toolset
+
+Different toolsets require specific roles for your service account:
+
+- **Advisor tools**: `RHEL Advisor viewer`
+- **Inventory tools**: `Inventory Hosts viewer`
+- **Vulnerability tools**: `Vulnerability viewer`, `Inventory Hosts viewer`
+- **Remediation tools**: `Remediations user`
+
+#### Granting Permissions to Service Accounts
+
+By default, service accounts have no access. An organization administrator must assign permissions. The MCP server will only be able to perform tasks that it has permission to perform. For example, if the user wants to allow read-only operations and deny write operations, this can be accomplished via the permissions system.
+
+For detailed step-by-step instructions, see this video tutorial: [Service Account Permissions Setup](https://www.youtube.com/watch?v=UvNcmJsbg1w)
+
+1. **Log in as Organization Administrator** with User Access administrator role
+2. **Navigate to User Access Settings**: Click Settings (⚙️ Gear Icon) → "User Access" → "Groups"
+3. **Assign permissions** (choose one option):
+
+   **Option A - Create New Group:**
+   - Create new group (e.g., `mcp-service-accounts`)
+   - Add required roles (e.g., RHEL Advisor viewer, Inventory Hosts viewer, etc.)
+   - Add your service account to this group
+
+   **Option B - Use Existing Group:**
+   - Open existing group with necessary roles
+   - Go to "Service accounts" tab
+   - Add your service account to the group
+
+Your service account will inherit all roles from the assigned group.
+
+#### ⚠️ Security Remarks ⚠️
+
+If you start this MCP server locally (with `podman` or `docker`) make sure the container is not exposed to the internet. In this scenario it's probably fine to use `LIGHTSPEED_CLIENT_ID` and `LIGHTSPEED_CLIENT_SECRET` although your MCP Client (e.g. VSCode, Cursor, etc.) can get your `LIGHTSPEED_CLIENT_ID` and `LIGHTSPEED_CLIENT_SECRET`.
+
+For a deployment where you connect to this MCP server from a different machine, you should consider that `LIGHTSPEED_CLIENT_ID` and `LIGHTSPEED_CLIENT_SECRET` (or your JWT Bearer token) are transferred to the MCP server and you are trusting the remote MCP server not to leak them.
+
+In both cases if you are in doubt, please disable/remove the `LIGHTSPEED_CLIENT_ID` and `LIGHTSPEED_CLIENT_SECRET` from your account after you are done using the MCP server.
+
+#### Security & Incident Response (Emergency Revocation)
+
+To ensure safe AI operations and compliance with security standards, operators must be able to rapidly sever the connected LLM's access to Red Hat Lightspeed in the event of abnormal AI behavior, unexpected data exposure, or suspected token compromise.
+
+**Emergency "Kill Switch" Procedure:**
+
+If you need to immediately revoke AI access to the toolsets, execute the following steps:
+1. **Terminate the Server:** Stop the MCP container or local process immediately (e.g., run `podman ps` to find the container, then `podman stop <container_id>`).
+2. **Revoke Credentials:** Invalidate the Red Hat Client ID used by the MCP server to authenticate with Red Hat services. Go to the "[Service Accounts](https://console.redhat.com/iam/service-accounts)" page and `Delete` or `Reset` the credentials.
+
+Additionally you can remove the MCP server entry (e.g., `lightspeed-mcp` in your client's `mcp.json`) from your local LLM client's configuration to prevent the client from attempting to restart or reconnect to the server.
+
+If credential compromise or data exposure is suspected, assess breach notification obligations under applicable law (e.g., GDPR). For logging, debug mode, and compliance details, see [HACKING.md - Logging and Compliance](HACKING.md#logging-and-compliance).
+
+## Technical Info
+### Toolsets
+
+See [toolsets.md](toolsets.md) for the toolsets available in the MCP server.
+
+## Integrations
+
+### Prerequisites
+
+Make sure you have `podman` installed.<br>
+(Docker is fine too but the commands below have to be adapted accordingly)
+
+You can install it with `sudo dnf install podman` on Fedora/RHEL/CentOS,
+or on macOS follow the instructions of [Podman Desktop](https://podman-desktop.io/) or [Podman](https://podman.io/getting-started/installation).
+
+⚠️ **Note** if you use Podman on macOS, you sometimes need to set the path to `podman` explicitly.
+E.g. replace `podman` with the full path. Should be something like
+
+ * `/usr/local/bin/podman`
+ * `/opt/homebrew/bin/podman`
+ * …
+
+You can find the path by running `which podman` in your terminal.
+
+### Goose Desktop
+
+First check the [prerequisites](#prerequisites) section.
+
+#### Option 1: One-click installation (easiest)
+
+[![Install in Goose](https://goose-docs.ai/img/extension-install-dark.svg)](https://goose-docs.ai/extension?cmd=docker&arg=run&arg=--env&arg=LIGHTSPEED_CLIENT_ID&arg=--env&arg=LIGHTSPEED_CLIENT_SECRET&arg=--interactive&arg=--rm&arg=quay.io%2Fredhat-services-prod%2Finsights-management-tenant%2Finsights-mcp%2Fred-hat-lightspeed-mcp%3Alatest&id=red-hat-lightspeed-mcp&name=Red%20Hat%20Lightspeed%20MCP&description=Red%20Hat%20Lightspeed%20MCP%20server%20integration&env=LIGHTSPEED_CLIENT_ID%3DRed%20Hat%20Lightspeed%20Client%20ID&env=LIGHTSPEED_CLIENT_SECRET%3DRed%20Hat%20Lightspeed%20Client%20Secret)
+
+The badge uses an HTTPS redirect (`goose-docs.ai/extension?...`) that opens Goose Desktop's extension install flow.
+
+(Note: this uses the `quay.io` container image and `docker` as the command — Goose deeplinks only support `docker`, not `podman`. Use the manual install below if you rely on Podman.)
+
+After clicking, Goose prompts for `LIGHTSPEED_CLIENT_ID` and `LIGHTSPEED_CLIENT_SECRET`, then installs the extension. Start a new chat session to use it.
+
+#### Option 2: Manual STDIO installation
+
+1. Click the button in the **top-left** to open the sidebar.
+2. Click the **`Extensions`** button on the sidebar.
+3. Under **`Extensions`**, click **`Add custom extension`**.
+4. On the **`Add custom extension`** modal, enter:
+   - **Type**: `Standard IO`
+   - **ID**: `red-hat-lightspeed-mcp`
+   - **Name**: `Red Hat Lightspeed MCP`
+   - **Description**: `Red Hat Lightspeed MCP server integration`
+   - **Command**: `podman run --env LIGHTSPEED_CLIENT_ID --env LIGHTSPEED_CLIENT_SECRET --interactive --rm ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest`
+   - **Environment variables**: click **`Add`** for each:
+     - `LIGHTSPEED_CLIENT_ID` — Red Hat Lightspeed Client ID
+     - `LIGHTSPEED_CLIENT_SECRET` — Red Hat Lightspeed Client Secret
+   - **Timeout**: leave default (300s) unless needed
+5. Click **`Add`**.
+
+Docker users can replace `podman` with `docker` in the command. On macOS, if Goose cannot find `podman`, use the full path from `which podman` (see [prerequisites](#prerequisites)).
+
+### Cursor
+
+First check the [prerequisites](#prerequisites) section.
+
+#### Option 1: One-click installation (easiest)
+
+⚠️ Use **`Ctrl`/`Cmd`-click** to open in a **new tab**.<br>
+Otherwise the tab will close after installation and you won't see the documentation anymore.<br>
+[![Install with Podman in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=red-hat-lightspeed-mcp&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoicG9kbWFuIHJ1biAtLWVudiBMSUdIVFNQRUVEX0NMSUVOVF9JRCAtLWVudiBMSUdIVFNQRUVEX0NMSUVOVF9TRUNSRVQgLS1pbnRlcmFjdGl2ZSAtLXJtIHF1YXkuaW8vcmVkaGF0LXNlcnZpY2VzLXByb2QvaW5zaWdodHMtbWFuYWdlbWVudC10ZW5hbnQvaW5zaWdodHMtbWNwL3JlZC1oYXQtbGlnaHRzcGVlZC1tY3A6bGF0ZXN0IiwiZW52Ijp7IkxJR0hUU1BFRURfQ0xJRU5UX0lEIjoiIiwiTElHSFRTUEVFRF9DTElFTlRfU0VDUkVUIjoiIn19)<br>
+(Note: this uses the `quay.io` container image)
+
+#### Option 2: Manual STDIO installation
+
+Cursor doesn't seem to support `inputs` you need to add your credentials in the config file.
+To start the integration create a file `~/.cursor/mcp.json` with
+```
+{
+  "mcpServers": {
+    "lightspeed-mcp": {
+        "type": "stdio",
+        "command": "podman",
+        "args": [
+            "run",
+            "--env",
+            "LIGHTSPEED_CLIENT_ID",
+            "--env",
+            "LIGHTSPEED_CLIENT_SECRET",
+            "--interactive",
+            "--rm",
+            "ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest"
+        ],
+        "env": {
+            "LIGHTSPEED_CLIENT_ID": "",
+            "LIGHTSPEED_CLIENT_SECRET": ""
+        }
+    }
+  }
+}
+```
+
+If you see the error `Some tools have naming issues and may be filtered out.`, see [Known Issues](#known-issues).
+
+#### Option 3: Manual Streamable HTTP installation (advanced)
+
+start the server:
+
+```
+podman run --net host --rm ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest http
+```
+
+then integrate using **service account credentials**:
+
+```
+{
+    "mcpServers": {
+        "lightspeed-mcp": {
+            "type": "http",
+            "url": "http://localhost:8000/mcp",
+            "headers": {
+                "lightspeed-client-id": "",
+                "lightspeed-client-secret": ""
+            }
+        }
+    }
+}
+```
+
+or alternatively using a **JWT Bearer token**:
+
+```
+{
+    "mcpServers": {
+        "lightspeed-mcp": {
+            "type": "http",
+            "url": "http://localhost:8000/mcp",
+            "headers": {
+                "Authorization": "Bearer <YOUR_JWT_TOKEN>"
+            }
+        }
+    }
+}
+```
+
+### VSCode
+
+First check the [prerequisites](#prerequisites) section.
+
+#### Option 1: One-click installation (easiest)
+
+[![Install with Podman in VS Code](https://img.shields.io/badge/VS_Code-Install_Red_Hat_Lightspeed_MCP-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=red-hat-lightspeed-mcp&config=%7B%22type%22%3A%20%22stdio%22%2C%20%22command%22%3A%20%22podman%22%2C%20%22args%22%3A%20%5B%22run%22%2C%20%22--env%22%2C%20%22LIGHTSPEED_CLIENT_ID%22%2C%20%22--env%22%2C%20%22LIGHTSPEED_CLIENT_SECRET%22%2C%20%22--interactive%22%2C%20%22--rm%22%2C%20%22quay.io%2Fredhat-services-prod%2Finsights-management-tenant%2Finsights-mcp%2Fred-hat-lightspeed-mcp%3Alatest%22%5D%2C%20%22env%22%3A%20%7B%22LIGHTSPEED_CLIENT_ID%22%3A%20%22%24%7Binput%3Alightspeed_client_id%7D%22%2C%20%22LIGHTSPEED_CLIENT_SECRET%22%3A%20%22%24%7Binput%3Alightspeed_client_secret%7D%22%7D%7D&inputs=%5B%7B%22id%22%3A%20%22lightspeed_client_id%22%2C%20%22type%22%3A%20%22promptString%22%2C%20%22description%22%3A%20%22Enter%20the%20Red%20Hat%20Lightspeed%20Client%20ID%22%2C%20%22default%22%3A%20%22%22%2C%20%22password%22%3A%20true%7D%2C%20%7B%22id%22%3A%20%22lightspeed_client_secret%22%2C%20%22type%22%3A%20%22promptString%22%2C%20%22description%22%3A%20%22Enter%20the%20Red%20Hat%20Lightspeed%20Client%20Secret%22%2C%20%22default%22%3A%20%22%22%2C%20%22password%22%3A%20true%7D%5D)<br>
+(Note: this uses the `quay.io` container image)
+
+#### Option 2: Manual STDIO installation
+
+For the usage in your project, create a file called `.vscode/mcp.json` with
+the following content.
+
+```
+{
+    "inputs": [
+        {
+            "id": "lightspeed_client_id",
+            "type": "promptString",
+            "description": "Enter the Red Hat Lightspeed Client ID",
+            "default": "",
+            "password": true
+        },
+        {
+            "id": "lightspeed_client_secret",
+            "type": "promptString",
+            "description": "Enter the Red Hat Lightspeed Client Secret",
+            "default": "",
+            "password": true
+        }
+    ],
+    "servers": {
+        "lightspeed-mcp": {
+            "type": "stdio",
+            "command": "podman",
+            "args": [
+                "run",
+                "--env",
+                "LIGHTSPEED_CLIENT_ID",
+                "--env",
+                "LIGHTSPEED_CLIENT_SECRET",
+                "--interactive",
+                "--rm",
+                "ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest"
+            ],
+            "env": {
+                "LIGHTSPEED_CLIENT_ID": "${input:lightspeed_client_id}",
+                "LIGHTSPEED_CLIENT_SECRET": "${input:lightspeed_client_secret}"
+            }
+        }
+    }
+}
+```
+
+### Gemini CLI
+
+First check the [prerequisites](#prerequisites) section.
+
+#### Option 1: Manual STDIO installation
+To start the integration create a file `~/.gemini/settings.json` with the following command:
+
+```
+{
+    ...
+    "mcpServers": {
+        "lightspeed-mcp": {
+            "type": "stdio",
+            "command": "podman",
+            "args": [
+                "run",
+                "--env",
+                "LIGHTSPEED_CLIENT_ID=<YOUR_CLIENT_ID>",
+                "--env",
+                "LIGHTSPEED_CLIENT_SECRET=<YOUR_CLIENT_SECRET>",
+                "--interactive",
+                "--rm",
+                "ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest"
+            ]
+        }
+    }
+}
+```
+
+#### Option 2: Manual Streamable HTTP installation (advanced)
+
+start the server:
+
+```
+podman run --net host --rm ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest http
+```
+
+> [!NOTE]
+> For podman machine on a mac you will need to set the host explicitly and expose the port
+>
+> ```
+>   podman run -p 8000:8000 --rm ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest http --host 0.0.0.0
+> ```
+
+then integrate using **service account credentials**:
+
+```
+{
+    ...
+    "mcpServers": {
+        "lightspeed-mcp": {
+            "httpUrl": "http://localhost:8000/mcp",
+            "headers": {
+                "lightspeed-client-id": "<YOUR_CLIENT_ID>",
+                "lightspeed-client-secret": "<YOUR_CLIENT_SECRET>"
+            }
+        }
+    }
+}
+```
+
+or alternatively using a **JWT Bearer token**:
+
+```
+{
+    ...
+    "mcpServers": {
+        "lightspeed-mcp": {
+            "httpUrl": "http://localhost:8000/mcp",
+            "headers": {
+                "Authorization": "Bearer <YOUR_JWT_TOKEN>"
+            }
+        }
+    }
+}
+```
+
+### Claude Desktop
+
+First check the [prerequisites](#prerequisites) section.
+
+For Claude Desktop there is an extension file in the [release section](https://github.com/RedHatInsights/insights-mcp/releases) of the project.
+
+Just download the `red-hat-lightspeed-mcp*.mcpb` file (or `red-hat-lightspeed-mcp*.dxt` for legacy format) and add this in Claude Desktop with
+
+`Settings -> Extensions -> Advanced Extensions Settings -> Install Extension…`
+
+### CLine with VSCode
+
+First check the [prerequisites](#prerequisites) section.
+
+First off, start the SSE server with `sse` argument:
+
+```bash
+export LIGHTSPEED_CLIENT_ID=<YOUR_CLIENT_ID>
+export LIGHTSPEED_CLIENT_SECRET=<YOUR_CLIENT_SECRET>
+podman run --env LIGHTSPEED_CLIENT_ID --env LIGHTSPEED_CLIENT_SECRET --net host --rm ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest sse
+```
+
+In the `CLine -> Manage MCP Servers` interface, add a new server name and URL:
+`http://localhost:9000/sse`. It shall create the following config:
+
+```json
+{
+  "mcpServers": {
+    "lightspeed-mcp": {
+      "disabled": false,
+      "type": "sse",
+      "url": "http://localhost:9000/sse"
+    }
+  }
+}
+```
+
+Ensure the `type` is `sse` as CLine does not support `HTTP` transport yet.
+
+### Generic STDIO
+
+First check the [prerequisites](#prerequisites) section.
+
+For generic integration into other tools via STDIO, you should set the environment variables
+`LIGHTSPEED_CLIENT_ID` and `LIGHTSPEED_CLIENT_SECRET` and use this command for an
+integration using podman:
+
+```bash
+export LIGHTSPEED_CLIENT_ID=<YOUR_CLIENT_ID>
+export LIGHTSPEED_CLIENT_SECRET=<YOUR_CLIENT_SECRET>
+podman run --env LIGHTSPEED_CLIENT_ID --env LIGHTSPEED_CLIENT_SECRET --interactive --rm ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest
+```
+
+It is the MCP API what is exposed through standard input, not a chat interface.
+You need an MCP client with "agent capabilities" to connect to the `red-hat-lightspeed-mcp` server and really use it.
+
+#### Claude Code
+
+First check the [prerequisites](#prerequisites) section.
+
+Claude Code requires a slight change to the podman command, as the host environment is not
+available when it runs. The credentials must be copied into the configuration instead, which
+can be done with the following command after setting `LIGHTSPEED_CLIENT_ID` and
+`LIGHTSPEED_CLIENT_SECRET` environment variables:
+
+```bash
+export LIGHTSPEED_CLIENT_ID=<YOUR_CLIENT_ID>
+export LIGHTSPEED_CLIENT_SECRET=<YOUR_CLIENT_SECRET>
+claude mcp add red-hat-lightspeed-mcp -- podman run --env LIGHTSPEED_CLIENT_ID=$LIGHTSPEED_CLIENT_ID --env LIGHTSPEED_CLIENT_SECRET=$LIGHTSPEED_CLIENT_SECRET --interactive --rm ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest
+```
+
+or just set the variables in the command directly:
+
+```bash
+claude mcp add red-hat-lightspeed-mcp -- podman run --env LIGHTSPEED_CLIENT_ID=<YOUR_CLIENT_ID> --env LIGHTSPEED_CLIENT_SECRET=<YOUR_CLIENT_SECRET> --interactive --rm ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest
+```
+
+To verify setup was successful, within the Claude terminal execute the command:
+```bash
+/mcp
+```
+If successful, you should see `red-hat-lightspeed-mcp` listed under Manage MCP servers with a green check mark connected status besides it.
+
+### URL overrides
+
+If you are using a non-standard RH Lightspeed URL, set the environment variables
+* `LIGHTSPEED_BASE_URL`
+* `LIGHTSPEED_SSO_BASE_URL`
+* `LIGHTSPEED_PROXY_URL`
+accordingly.
+
+## Agent Skills
+
+This project includes [Agent Skills](https://agentskills.io/specification) — portable instructions that teach AI assistants how to set up and use Red Hat Lightspeed MCP. Skills are loaded automatically when you open the project in a supported assistant (Cursor, Claude Code, etc.).
+
+### Install with Lola
+
+[Lola](https://docs.getlola.dev/) is a universal AI Context Package Manager. Use it to install Lightspeed MCP skills into any supported AI assistant without cloning the full repo:
+
+```bash
+# Install Lola (one-time)
+uv tool install lola-ai
+
+# Add the Lightspeed marketplace (one-time)
+lola market add rh-lightspeed https://raw.githubusercontent.com/RedHatInsights/insights-mcp/main/lola-marketplace.yml
+
+# Install skills to your AI assistant
+lola install rh-lightspeed-mcp-skills -a cursor
+lola install rh-lightspeed-mcp-skills -a claude-code
+lola install rh-lightspeed-mcp-skills -a gemini-cli
+```
+
+Available skills are in the [`.agents/skills/`](.agents/skills/) directory.
+
+## Examples
+
+This [blog post](https://developers.redhat.com/articles/2026/01/07/manage-ai-powered-inventory-using-red-hat-lightspeed#) has a few examples on how to use the RH Lightspeed MCP server.
+
+You can also ask LLM you just attached to the MCP server to.
+e.g.
+```
+Please explain red-hat-lightspeed-mcp and what I can do with it?
+```
+
+For example questions specific to each toolset please have a look at the test files:
+
+ * [`image-builder-mcp`](src/image_builder_mcp/tests/test_llm_integration_easy.py#L20)
+ * [`inventory-mcp`](src/inventory_mcp/test_prompts.md)
+ * [`planning-mcp`](src/planning_mcp/test_prompts.md)
+ * [`remediations-mcp`](src/remediations_mcp/test_prompts.md)
+ * [`advisor-mcp`](src/advisor_mcp/test_prompts.md)
+ * [`vulnerability-mcp`](src/vulnerability_mcp/test_prompts.md)
+
+## CLI
+
+For some use cases it might be needed to use the MCP server directly from the command line.
+See [usage.md](usage.md) for the usage of the MCP server.
+
+## Releases
+There are two container images published for this MCP server.
+
+ * `ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest`
+ * `quay.io/redhat-services-prod/insights-management-tenant/insights-mcp/red-hat-lightspeed-mcp:latest`
+
+They are both based on `main` branch and you can use either of them.
+
+Insights-branded images are deprecated but still available for a while but might be removed in the future.
+
+ * `ghcr.io/redhatinsights/insights-mcp:latest`
+ * `quay.io/redhat-services-prod/insights-management-tenant/insights-mcp/insights-mcp:latest`
+
+
+## Known Issues
+
+### Cursor
+
+When using Cursor with the MCP server, you might encounter the following error:
+
+```
+Some tools have naming issues and may be filtered out.
+
+… exceeds 60 characters…
+```
+
+Please rename your MCP server name in the MCP configuration file (`mcp.json`) to a shorter name.
+
+
+```
+{
+  "mcpServers": {
+    "red-hat-lightspeed-mcp-this-will-be-too-long": { # <--- rename this
+…
+```
+
+## Disclaimer
+
+This software is provided "as is" without warranty of any kind, either express or implied. Use at your own risk. The authors and contributors are not liable for any damages or issues that may arise from using this software.
+
+## Shared auth package
+
+The OAuth/JWT auth provider used by this server for HTTP transport deployments is provided by
+[`rh-fastmcp-server-commons`](https://pypi.org/project/rh-fastmcp-server-commons/), a PyPI package
+shared across Red Hat FastMCP servers. See [HACKING.md](HACKING.md#hosted-mcp-server-with-auth-provider-http-transport)
+for usage and environment variable reference.
+
+## Contributing
+Please refer to the [hacking guide](HACKING.md) to learn more.

--- a/.agents/skills/getting-started/SKILL.md
+++ b/.agents/skills/getting-started/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: getting-started
+description: >
+  Help users set up and start using the Red Hat Lightspeed MCP server for
+  managing RHEL systems via AI agents. Use when the user asks how to install,
+  configure, or connect the MCP server, needs help with authentication
+  (service accounts, credentials, tokens), wants to know what toolsets are
+  available, asks what they can do with this project, or is looking for
+  first-steps guidance — even if they just say "get started", "how do I use
+  this", or "what can I do".
+license: Apache-2.0
+metadata:
+  author: RedHatInsights
+  version: "1.0"
+---
+
+# Getting Started with Red Hat Lightspeed MCP
+
+Guide the user from zero to a working MCP connection. Adapt the steps below
+to their situation — ask which MCP client they use and whether they already
+have a Red Hat service account before walking through everything.
+
+## Install Skills with Lola (optional)
+
+If the user wants the Lightspeed MCP skills installed into their AI assistant
+without cloning the full repo, they can use
+[Lola](https://docs.getlola.dev/) — a universal AI Context Package Manager.
+
+```bash
+# Install Lola (one-time)
+uv tool install git+https://github.com/RedHatProductSecurity/lola
+
+# Add the Lightspeed marketplace (one-time)
+lola market add lightspeed https://raw.githubusercontent.com/RedHatInsights/insights-mcp/main/lola-marketplace.yml
+
+# Install skills to your AI assistant
+lola install rh-lightspeed-mcp-skills -a cursor
+lola install rh-lightspeed-mcp-skills -a claude-code
+lola install rh-lightspeed-mcp-skills -a gemini-cli
+```
+
+This installs the skills to the assistant's native directory (e.g.,
+`.cursor/skills/`, `.claude/skills/`). Users who clone the repo already have
+the skills in `.agents/skills/` — Lola is for distribution without cloning.
+
+## Setup Flow
+
+### 1. Prerequisites
+
+The user needs:
+- `podman` or `docker` installed
+- A Red Hat account at https://console.redhat.com
+- An MCP-compatible client
+
+On macOS, if `podman` is installed but the client can't find it, use the full
+path from `which podman` (usually `/opt/homebrew/bin/podman` or
+`/usr/local/bin/podman`).
+
+### 2. Authentication
+
+**THIS STEP MUST BE PERFORMED BY THE USER — NOT BY THE AGENT.**
+Do not attempt to create, modify, or manage service accounts or permissions
+on behalf of the user. Only provide instructions and let the user act.
+
+The user needs a Red Hat service account. Direct them to do the following:
+
+1. Go to https://console.redhat.com → Settings (gear icon) → "Service Accounts"
+2. Create a service account → save the **Client ID** and **Client Secret**
+3. Provide those values as `LIGHTSPEED_CLIENT_ID` and `LIGHTSPEED_CLIENT_SECRET`
+
+Service accounts have **no permissions by default**. An org admin must grant
+roles via Settings → User Access → Groups. Tell the user which roles are
+needed based on the toolsets they plan to use:
+
+| Toolset | Required Roles |
+|---|---|
+| advisor | RHEL Advisor viewer |
+| inventory | Inventory Hosts viewer |
+| vulnerability | Vulnerability viewer, Inventory Hosts viewer |
+| remediations | Remediations user |
+
+If API calls return **403**, this is almost always a missing role — tell the
+user to check their service account permissions.
+
+For a step-by-step video walkthrough of granting permissions, direct the user
+to: https://www.youtube.com/watch?v=UvNcmJsbg1w
+
+### 3. Connect the MCP Client
+
+Ask the user which client they're using.
+
+Detailed per-client configuration (Cursor, VS Code, Claude Desktop, Claude
+Code, Goose, Gemini CLI, CLine, HTTP transport, generic STDIO) is in the
+project README. When this skill is installed via Lola, the README is available
+at `../README.md` relative to this file. If the user cloned the repo, it's at
+the project root.
+
+Look up the matching section in the README and walk the user through it.
+
+### 4. Choose Toolsets
+
+All toolsets load by default. To limit which ones are active, add
+`--toolset=<name>,<name>` to the container args.
+
+| Toolset | What it does |
+|---|---|
+| **vulnerability** | CVE analysis, system-CVE mapping, explain why CVEs affect your systems |
+| **advisor** | Configuration issue recommendations (availability, stability, performance, security) |
+| **inventory** | Host discovery, system profiles, tags, fleet overview |
+| **image-builder** | Create and manage custom RHEL image blueprints and composes |
+| **remediations** | Generate Ansible playbooks to fix CVEs on specific systems |
+| **planning** | RHEL and AppStream lifecycle dates, upcoming deprecations and changes |
+| **rhsm** | Activation keys for Red Hat Subscription Management |
+| **content-sources** | Repository listing and filtering |
+| **rbac** | Query your role-based access permissions |
+
+### 5. Verify the Connection
+
+Suggest these prompts to confirm things work end-to-end:
+
+- "List my top 5 most recently active hosts" (tests inventory + auth)
+- "Show me the top 5 critical CVEs affecting my account" (tests vulnerability)
+- "What advisor recommendations are impacting my systems?" (tests advisor)
+
+If any fail with an auth error, call `get_mcp_version` to check whether the
+server is up-to-date, and revisit the permissions table above.
+
+## Gotchas
+
+- **Read-only by default.** Write tools (create blueprints, compose images,
+  create remediation playbooks) are hidden unless the server is started with
+  `--all-tools`. If the user asks to create something and the tool doesn't
+  exist, tell them to add `--all-tools` to the container args and restart.
+- **Tool naming convention.** Every tool is prefixed with its toolset name:
+  `vulnerability_get_cves`, `advisor_get_active_rules`, `inventory_list_hosts`.
+  Always use the full prefixed name.
+- **Cursor tool name length limit.** If Cursor says "Some tools have naming
+  issues and may be filtered out", the server name in `mcp.json` is too long.
+  Use `lightspeed-mcp` (not `red-hat-lightspeed-mcp`).
+- **macOS podman path.** Some clients can't find `podman` on macOS. Replace
+  `podman` with the full path from `which podman` (usually
+  `/opt/homebrew/bin/podman` or `/usr/local/bin/podman`).
+- **Cached tool descriptions.** After rebuilding the container, fully restart
+  the IDE — the "restart MCP server" button doesn't always pick up new tool
+  descriptions.
+- **Version checking.** If something seems broken, call `get_mcp_version`. It
+  compares the running version against the latest GitHub release and shows
+  what changed between them.
+- **Podman on macOS with HTTP/SSE.** When using podman machine on macOS, set
+  the host explicitly and expose the port:
+  `podman run -p 8000:8000 --rm ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest http --host 0.0.0.0`
+
+## Security
+
+- Never expose the container to the internet when running locally.
+- Credentials are transferred to the MCP server — only trust servers you
+  control.
+- To revoke access immediately: stop the container, then delete or reset the
+  service account at https://console.redhat.com/iam/service-accounts.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ run-oauth: build ## Run the MCP server with OAuth transport
 ALL_PYTHON_FILES := $(shell find src -name "*.py")
 
 .PHONY: generate-docs prepare-mkdocs build-mkdocs serve-mkdocs
-generate-docs: usage.md toolsets.md catalog-info.yaml docs/architecture-structure.svg docs/architecture-deployment.svg prepare-mkdocs ## Generate documentation from the MCP server
+generate-docs: usage.md toolsets.md catalog-info.yaml docs/architecture-structure.svg docs/architecture-deployment.svg prepare-mkdocs .agents/skills/README.md ## Generate documentation from the MCP server
 
 prepare-mkdocs: usage.md toolsets.md docs/architecture-structure.svg docs/architecture-deployment.svg README.md HACKING.md ## Prepare MkDocs staging files under docs/mkdocs/
 	uv run python scripts/prepare_mkdocs.py
@@ -227,3 +227,6 @@ toolsets.md: $(ALL_PYTHON_FILES) Makefile
 
 docs/architecture-structure.svg docs/architecture-deployment.svg docs/architecture-structure.png docs/architecture-deployment.png: HACKING.md scripts/generate_diagrams.py
 	uv run python scripts/generate_diagrams.py --format svg,png
+
+.agents/skills/README.md: README.md
+	cp README.md .agents/skills/README.md

--- a/README.md
+++ b/README.md
@@ -449,6 +449,29 @@ If you are using a non-standard RH Lightspeed URL, set the environment variables
 * `LIGHTSPEED_PROXY_URL`
 accordingly.
 
+## Agent Skills
+
+This project includes [Agent Skills](https://agentskills.io/specification) — portable instructions that teach AI assistants how to set up and use Red Hat Lightspeed MCP. Skills are loaded automatically when you open the project in a supported assistant (Cursor, Claude Code, etc.).
+
+### Install with Lola
+
+[Lola](https://docs.getlola.dev/) is a universal AI Context Package Manager. Use it to install Lightspeed MCP skills into any supported AI assistant without cloning the full repo:
+
+```bash
+# Install Lola (one-time)
+uv tool install lola-ai
+
+# Add the Lightspeed marketplace (one-time)
+lola market add rh-lightspeed https://raw.githubusercontent.com/RedHatInsights/insights-mcp/main/lola-marketplace.yml
+
+# Install skills to your AI assistant
+lola install rh-lightspeed-mcp-skills -a cursor
+lola install rh-lightspeed-mcp-skills -a claude-code
+lola install rh-lightspeed-mcp-skills -a gemini-cli
+```
+
+Available skills are in the [`.agents/skills/`](.agents/skills/) directory.
+
 ## Examples
 
 This [blog post](https://developers.redhat.com/articles/2026/01/07/manage-ai-powered-inventory-using-red-hat-lightspeed#) has a few examples on how to use the RH Lightspeed MCP server.

--- a/docs/mkdocs/index.md
+++ b/docs/mkdocs/index.md
@@ -449,6 +449,29 @@ If you are using a non-standard RH Lightspeed URL, set the environment variables
 * `LIGHTSPEED_PROXY_URL`
 accordingly.
 
+## Agent Skills
+
+This project includes [Agent Skills](https://agentskills.io/specification) — portable instructions that teach AI assistants how to set up and use Red Hat Lightspeed MCP. Skills are loaded automatically when you open the project in a supported assistant (Cursor, Claude Code, etc.).
+
+### Install with Lola
+
+[Lola](https://docs.getlola.dev/) is a universal AI Context Package Manager. Use it to install Lightspeed MCP skills into any supported AI assistant without cloning the full repo:
+
+```bash
+# Install Lola (one-time)
+uv tool install lola-ai
+
+# Add the Lightspeed marketplace (one-time)
+lola market add rh-lightspeed https://raw.githubusercontent.com/RedHatInsights/insights-mcp/main/lola-marketplace.yml
+
+# Install skills to your AI assistant
+lola install rh-lightspeed-mcp-skills -a cursor
+lola install rh-lightspeed-mcp-skills -a claude-code
+lola install rh-lightspeed-mcp-skills -a gemini-cli
+```
+
+Available skills are in the [`.agents/skills/`](.agents/skills/) directory.
+
 ## Examples
 
 This [blog post](https://developers.redhat.com/articles/2026/01/07/manage-ai-powered-inventory-using-red-hat-lightspeed#) has a few examples on how to use the RH Lightspeed MCP server.

--- a/lola-marketplace.yml
+++ b/lola-marketplace.yml
@@ -1,0 +1,19 @@
+name: "Red Hat Lightspeed Marketplace"
+description: "Agent skills for Red Hat Lightspeed MCP — manage RHEL systems via AI assistants"
+version: "1.0.0"
+
+modules:
+  - name: "rh-lightspeed-mcp-skills"
+    description: "Agent skills for Red Hat Lightspeed MCP: setup, vulnerability management, inventory, advisor, image builder, and more"
+    version: "1.0.0"
+    repository: "https://github.com/RedHatInsights/insights-mcp.git"
+    path: ".agents"
+    tags:
+      - "red-hat"
+      - "lightspeed"
+      - "rhel"
+      - "mcp"
+      - "vulnerability"
+      - "inventory"
+      - "advisor"
+      - "image-builder"


### PR DESCRIPTION
This PR implements the lola package manager market place, allowing users to install the skills using [lola](https://docs.getlola.dev/) and add the first skill: getting-started, that helps user on how to setup and use Lightspeed MCP