### PR TITLE
Add github token to publish action to avoid rate limits

### DIFF
--- a/.github/workflows/publish-mcp.yaml
+++ b/.github/workflows/publish-mcp.yaml
@@ -26,6 +26,8 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Install deps and run tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv tool install . -e
           make install-test-deps


### PR DESCRIPTION
Adding the token should help in avoiding rate limits like this:
https://github.com/RedHatInsights/insights-mcp/actions/runs/33685098618/job/100430551833